### PR TITLE
update dashboard generation to grafana2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "commander": "^2.6.0",
     "farmhash": "^1.1.0",
     "zero-config": "^5.0.0",
-    "grafana-dash-gen": "uber/grafana-dash-gen#v1.0.1",
+    "grafana-dash-gen": "uber/grafana-dash-gen#41a17abfa174fdda048f9a1084bc302dec28e6ff",
     "strformat": "^0.0.7"
   }
 }

--- a/tools/grafana-dash/config/common.json
+++ b/tools/grafana-dash/config/common.json
@@ -1,7 +1,7 @@
 {
     "grafana": {
         "cookie": "auth-openid=<your cookie here>",
-        "url": "https://grafana-dash-url"
+        "url": "https://grafana.example.com/grafana2/api/dashboards/db/"
     },
     "gen-dashboard": {
         "dashboard-title": "my-ringpop-dashboard",


### PR DESCRIPTION
Unfortunately the grafana2 support is not yet in master of
uber/grafana-dash-gen, so we have to use its grafana2 branch for now.
Example URL taken from https://github.com/uber/grafana-dash-gen/blob/grafana2/example.js#L17 .
