### PR TITLE
Add a tap filter, useful for parsing test results

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -17,8 +17,9 @@
     "lodash": "^3.10.1",
     "node-uuid": "^1.4.3",
     "pre-commit": "^0.0.9",
+    "tap-parser": "^1.2.2",
     "tape": "^4.2.0",
     "tchannel": "^2.4.6",
     "underscore": "^1.8.3"
-  }
+  },
 }

--- a/test/tap-filter.js
+++ b/test/tap-filter.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Reads tap-compliant data from stdin outputs successes to stdout and errors
+ * to stderr.
+ */
+var os = require('os')
+var parser = require('tap-parser');
+
+// Exit using the correct exit code depending on whether the tests passed or
+// failed.
+var p = parser(function (results) {
+	process.exit(results.ok ? 0 : 1);
+});
+
+// Parse the data from stdin and output success to stdout and errors to stderr.
+// Malformed data (or data that cannot be parsed) will be thrown away.
+p.on('assert', function (assert) {
+	if (assert.ok) {
+		console.log('ok ' +  assert.id + ' ' + assert.name);
+	} else {
+		var buffer = '';
+		buffer += 'not ok ' +  assert.id + ' ' + assert.name + os.EOL;
+		buffer += '  ---' + os.EOL;
+		buffer += '    operator: ' + assert.diag.operator + os.EOL;
+		buffer += '    expected: ' + assert.diag.expected + os.EOL;
+		buffer += '    actual:   ' + assert.diag.actual + os.EOL;
+		buffer += '    at:       ' + assert.diag.at + os.EOL;
+		buffer += '  ...';
+		console.error(buffer);
+	}
+});
+
+process.stdin.pipe(p);


### PR DESCRIPTION
Our tap-filter parses tap messages from stdin and outputs successes to
stdout and errors to stderr.

@uber/ringpop 