### PR TITLE
Integration test improvements

### DIFF
--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -27,6 +27,8 @@ var dsl = require('./ringpop-assert');
 var programPath, programInterpreter;
 var clusterSizes = [1, 2, 3, 4, 5, 6, 7, 10, 21, 25, 30];
 
+// Global counter to record how many tests have failed.
+var testFailures = 0;
 
 function main() {   
     program
@@ -70,6 +72,11 @@ function main() {
 
     // require('./network-blip-tests');
     // require('./revive-tests');
+
+    // If one or more tests failed, exit with a non-zero exit code.
+    if (testFailures > 0) {
+        process.exit(1);
+    }
 }
 
 function getProgramPath() {
@@ -87,11 +94,18 @@ function getClusterSizes(min) {
     return clusterSizes;
 }
 
+// Exported function that increments the testFailures counter. Called by the
+// tests when a failure occurs.
+function incrementFailureCount() {
+    testFailures++;
+}
+
 // ./util uses this so we want to export it before require('./util') happens somewhere
 module.exports = {
     getProgramInterpreter: getProgramInterpreter,
     getProgramPath: getProgramPath,
     getClusterSizes: getClusterSizes,
+    incrementFailureCount: incrementFailureCount,
 };
 
 if (require.main === module) {

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -22,11 +22,15 @@ var dsl = require('./ringpop-assert');
 var TestCoordinator = require('./test-coordinator');
 var getProgramPath = require('./it-tests').getProgramPath;
 var getProgramInterpreter = require('./it-tests').getProgramInterpreter;
+var main = require('./it-tests');
 // test is like normal tape test but also prints t.error.details if a fail occured
 var Test = require('tape');
 function test(msg, opts, cb) {
     var t = Test(msg, opts, cb);
     t.on('result', function(res) {
+        if (!res.ok) {
+            main.incrementFailureCount()
+        }
         if(!res.ok && res.error.details !== undefined) {
             console.log('============== error details ===============');
             console.log();


### PR DESCRIPTION
OK last one guys, I promise.

This PR includes two changes:

1. Make integration tests exit with non-zero code on failures

  Enough said.

2. Change behaviour of tap-filter, for the ringpop-go integration tests

  This is a bit of a change of direction. It turns out it is actually more sane just to provide a `-v` switch, where by default we print only failures and `-v` will print successes as well. And do all this on stdout. This matches the behaviour of, say, `go test -v`.

Thanks!

@uber/ringpop 