### PR TITLE
fix flappy "ping-req not ok" test

### DIFF
--- a/test/fake-node.js
+++ b/test/fake-node.js
@@ -39,7 +39,7 @@ function FakeNode(options) {
     this.endpoints = {};
     this.enableEndpoints();
 
-    this.pingEnabled = true;
+    this.enabled = true;
 }
 
 FakeNode.prototype.enableEndpoints = function enableEndpoints() {
@@ -63,7 +63,7 @@ FakeNode.prototype.enableEndpoints = function enableEndpoints() {
 
 FakeNode.prototype.start = function start(callback) {
     var self = this;
-    self.enabled = true;
+
     self.tchannel = new TChannel();
     self.channel = this.tchannel.makeSubChannel({
         serviceName: 'ringpop'
@@ -122,21 +122,23 @@ FakeNode.prototype.joinHandler = function joinHandler(req, res, arg2, arg3) {
     return handleJoin(req, res, this.toMemberInfo(), membership);
 };
 
-FakeNode.prototype.disablePing = function disablePing() {
-    this.pingEnabled = false;
+FakeNode.prototype.disable = function disable() {
+    this.enabled = false;
 };
 
-FakeNode.prototype.enablePing = function enablePing() {
-    this.pingEnabled = true;
+FakeNode.prototype.enable = function enable() {
+    this.enabled = true;
 };
 
 FakeNode.prototype.pingHandler = function pingHandler(req, res, arg2, arg3) {
-    if (!this.pingEnabled) return; // Do nothing when disabled
+    if (!this.enabled) return; // Do nothing when disabled
 
     return handlePing(res);
 };
 
 FakeNode.prototype.pingReqHandler = function pingReqHandler(req, res, arg2, arg3) {
+    if (!this.enabled) return; // Do nothing when disabled
+
     // is the target alive?
     var target = safeParse(arg3).target;
     var status = true;

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -590,7 +590,7 @@ function disableAllNodes(t, tc) {
 function disableAllNodesPing(t, tc) {
     return function disableAllNodesPing(list, cb) {
         tc.fakeNodes.forEach(function (fn) {
-            fn.disablePing();
+            fn.disable();
         });
         cb(list);
     };


### PR DESCRIPTION
In ringpop, a node E is declared suspect trough the indirect ping mechanism: When a node A fails to ping E; A randomly picks three members to send a ping-req to, say B, C and D. Upon receiving the ping-reqs the three nodes will ping E and send back the status (ping ok / ping not ok) to A. If all three results are "ping not ok", A will declare E suspect.

In this test we check ringpop's behaviour from the perspective of B (or C or D). We check if B responds with "ping not ok" since E is not responsive. It is important that B doesn't decide that E is a suspect when the ping from B to E fails, which could be a likely programmer mistake. Therefore we check that the all members are alive and there are no suspects in B's membership at the end of the test.

However, sometimes B found out that E is suspect trough it's own ping mechanism, which caused the test to fail. By disabling all pings and ping-reqs, B will never be able to decide if E is unreachable and therefor no longer declares E suspect.

rewrite comment