### PR TITLE
Fix redundant if in argument handling

### DIFF
--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -494,16 +494,7 @@ function assertStatusCounts(t, actual, expected) {
     return !failed;
 }
 
-function waitForStatsAssertStatus(t, tc, statusCountsOralive, suspect, faulty) {
-    var statusCounts = statusCountsOralive;
-    if (typeof statusCountsOralive === 'numer') {
-        statusCounts = {
-            alive: statusCountsOralive,
-            suspect: suspect,
-            faulty: faulty
-        };
-    }
-
+function waitForStatsAssertStatus(t, tc, statusCounts) {
     return function waitForStatsAssertStatus(list, cb) {
         var ix = _.findIndex(list, {type: events.Types.Stats});
         if (ix === -1) {


### PR DESCRIPTION
The legacy function signature is now redundant, we can remove it.