### PR TITLE
Feature/admin reap

### DIFF
--- a/schema/change.json
+++ b/schema/change.json
@@ -23,6 +23,9 @@
         },
         "timestamp": {
             "type": "number"
+        },
+        "tombstone": {
+            "type": "boolean"
         }
     },
     "required": [

--- a/schema/protocol-join-response.json
+++ b/schema/protocol-join-response.json
@@ -32,6 +32,9 @@
                     },
                     "sourceIncarnationNumber": {
                         "type": "number"
+                    },
+                    "tombstone": {
+                        "type": "boolean"
                     }
                 },
                 "required": [

--- a/test/events.js
+++ b/test/events.js
@@ -32,7 +32,8 @@ var Types = {
     AdminGossipTick: 'AdminGossipTick',
     AdminLookup: 'AdminLookup',
     AdminMemberLeave: 'AdminMemberLeave',
-    AdminMemberJoin: 'AdminMemberJoin'
+    AdminMemberJoin: 'AdminMemberJoin',
+    AdminReap: 'AdminReap'
 };
 
 function endpointToEventType(endpoint) {
@@ -59,6 +60,8 @@ function endpointToEventType(endpoint) {
             return Types.AdminMemberLeave;
         case '/admin/member/join':
             return Types.AdminMemberJoin;
+        case '/admin/reap':
+            return Types.AdminReap
         default:
             return Types.UnknownRequest;
     }

--- a/test/protocol-join.js
+++ b/test/protocol-join.js
@@ -21,6 +21,7 @@
 var farmhash = require('farmhash');
 var makeHostPort = require('./util').makeHostPort;
 var checksum = require('./membership-checksum').checksum;
+var _ = require('underscore');
 
 // send and handle join requests (check bottom of file for example request)
 
@@ -36,12 +37,12 @@ function getJoinResponsePayload(respondingNode, membershipList) {
     var responderHostPort = makeHostPort(respondingNode.host, respondingNode.port);
 
     var membership = membershipList.map(function(member) {
-        return {
+        return _.extend({
             source: responderHostPort,
             address: makeHostPort(member.host, member.port),
             status: member.status,
             incarnationNumber: member.incarnationNumber
-        };
+        }, member.extraFields);
     });
 
     return {

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -121,3 +121,19 @@ test2('tombstone should not be applied when gossiped about but unknown to the SU
         ];
     })
 );
+
+test2('test /admin/reap endpoint', getClusterSizes(2), 20000,
+    prepareWithStatus(1, 'faulty', function(t, tc, n) { return [
+        dsl.assertStats(t, tc, {alive: n, faulty: 1}, {1: {status: 'faulty'}}),
+
+        dsl.callEndpoint(t, tc, '/admin/reap'),
+        dsl.validateEventBody(t, tc, {
+            type: events.Types.AdminReap,
+            direction: 'response'
+        }, 'Wait for AdminReap response', function (response) {
+            return response.body.status === 'ok';
+        }),
+
+        dsl.assertStats(t, tc, {alive: n, tombstone: 1}, {1: {status: 'tombstone'}}),
+    ];})
+);

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -194,7 +194,8 @@ test2('tombstone should be applied when sent as a flag', getClusterSizes(2), 200
             dsl.sendPing(t, tc, 0, {
                 sourceIx: 0,
                 subjectIx: 1,
-                status: 'tombstoneFlag'
+                status: 'faulty',
+                tombstone: true
             }),
             dsl.waitForPingResponse(t, tc, 0),
 
@@ -213,7 +214,8 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
             dsl.sendPing(t, tc, 0, {
                 sourceIx: 0,
                 subjectIx: 1,
-                status: 'tombstoneFlag'
+                status: 'faulty',
+                tombstone: true
             }),
             dsl.waitForPingResponse(t, tc, 0),
 

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -27,6 +27,21 @@ var prepareWithStatus = require('./test-util').prepareWithStatus;
 var dsl = require('./ringpop-assert');
 var getClusterSizes = require('./it-tests').getClusterSizes;
 
+
+test2('respond join requests with tombstone flag', getClusterSizes(2), 20000,
+    prepareWithStatus(1, 'tombstone', function(t, tc, n) { return [
+            dsl.sendJoin(t, tc, 1),
+            dsl.validateEventBody(t, tc, {
+                type: events.Types.Join,
+                direction: 'response'
+            }, "The membership list should contain a flagged tombstone", function (join) {
+                return _.filter(join.body.membership, { status: 'faulty', tombstone: true }).length === 1
+                    && _.filter(join.body.membership, { status: 'tombstone' }).length === 0;
+            }),
+    ];})
+);
+
+
 test2('join cluster with tombstone in memberlist', getClusterSizes(2), 20000, function init(t,tc, callback) {
     tc.addMembershipInformation('192.0.2.100:1234', 'tombstone', 127);
     callback();

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -825,6 +825,7 @@ var uuid = require('node-uuid');
 //    id: 'abcd-1234',
 //    sourceIncNoDelta: 1,
 //    subjectIncNoDelta: 1,
+//    tombstone: false,
 // }
 function piggyback(tc, opts) {
     if (opts === undefined) {
@@ -833,11 +834,7 @@ function piggyback(tc, opts) {
     update = {};
     update.id = opts.id || uuid.v4();
     update.status = opts.status;
-
-    if (update.status == 'tombstoneFlag') {
-        update.status = 'faulty';
-        update.tombstone = true;
-    }
+    update.tombstone = opts.tombstone || false;
 
     if(opts.sourceIx === 'sut') {
         update.source = tc.sutHostPort;

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -752,9 +752,19 @@ function validate(t, tc, scheme, deadline) {
     timer = setTimeout(function() {
         t.fail('timeout');
         tc.removeAllListeners('event');
+        tc.removeAllListeners('sut-died');
         tc.shutdown();
         t.end();
     }, deadline);
+
+    tc.on('sut-died', function(code) {
+        clearTimeout(timer);
+        t.fail('SUT crashed (code: ' + code + ')');
+        tc.removeAllListeners('event');
+        tc.removeAllListeners('sut-died');
+        tc.shutdown();
+        t.end();
+    });
 
     // flatten so arrays gets expanded and fns becomes one-dimensional
     fns = _.flatten(fns, true);
@@ -772,6 +782,7 @@ function validate(t, tc, scheme, deadline) {
             t.ok(true, 'validate done: all functions passed');
             tc.shutdown();
             tc.removeAllListeners('event');
+            tc.removeAllListeners('sut-died');
             t.end();
 
             inProgress = false;

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -834,6 +834,11 @@ function piggyback(tc, opts) {
     update.id = opts.id || uuid.v4();
     update.status = opts.status;
 
+    if (update.status == 'tombstoneFlag') {
+        update.status = 'faulty';
+        update.tombstone = true;
+    }
+
     if(opts.sourceIx === 'sut') {
         update.source = tc.sutHostPort;
         update.sourceIncarnationNumber = tc.sutIncarnationNumber;

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -257,7 +257,7 @@ TestCoordinator.prototype.getMembership = function getMembership() {
     }).concat(this.extraMembers);
 };
 
-TestCoordinator.prototype.addMembershipInformation = function(address, status, incarnationNumber) {
+TestCoordinator.prototype.addMembershipInformation = function(address, status, incarnationNumber, extraFields) {
     var parts = address.split(':', 2);
     var host = parts[0];
     var port = parts[1];
@@ -267,6 +267,7 @@ TestCoordinator.prototype.addMembershipInformation = function(address, status, i
         port: port,
         status: status,
         incarnationNumber: incarnationNumber,
+        extraFields: extraFields
     });
 };
 

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -174,6 +174,13 @@ TestCoordinator.prototype.startSUT = function startSUT() {
         console.error('Error: ' + err.message + ', failed to spawn ' +  self.sutProgram + ' on ' + self.sutHostPort);
     });
 
+    newProc.on('exit', function (code, signal) {
+        if (code) {
+            // non-clean exit
+            self.emit('sut-died', code);
+        }
+    });
+
     var who = util.format('sut:%s', this.sutHostPort);
     function logOutput(data) {
         var lines = data.toString('utf8').split('\n');


### PR DESCRIPTION
This add tests for reaping faulty nodes

1. It adds a test for the `/admin/reap` endpoint that can be used to reap all the currently faulty nodes manually.
2. It adds tests that specifically sends `tombstones` as a state and as a flag and checks that ringpop always gossips with the flag variant.

The later test is to make sure that ringpop stays compatible with older versions of `ringpop-go`