### PR TITLE
Detect checksum method used by SUT

### DIFF
--- a/test/protocol-join.js
+++ b/test/protocol-join.js
@@ -20,19 +20,18 @@
 
 var farmhash = require('farmhash');
 var makeHostPort = require('./util').makeHostPort;
-var checksum = require('./membership-checksum').checksum;
 var _ = require('underscore');
 
 // send and handle join requests (check bottom of file for example request)
 
 // Responding node and allNodes must have host, port, status, and incarnationNumber fields
-function handleJoin(req, res, respondingNode, membershipList) {
+function handleJoin(req, res, respondingNode, membershipList, checksumMethod) {
     res.headers.as = 'raw';
-    res.sendOk(null, JSON.stringify(getJoinResponsePayload(respondingNode, membershipList)));
+    res.sendOk(null, JSON.stringify(getJoinResponsePayload(respondingNode, membershipList, checksumMethod)));
 }
 
 // Responding node and allNodes must have host, port, status, and incarnationNumber fields
-function getJoinResponsePayload(respondingNode, membershipList) {
+function getJoinResponsePayload(respondingNode, membershipList, checksumMethod) {
     // add fake nodes to membership
     var responderHostPort = makeHostPort(respondingNode.host, respondingNode.port);
 
@@ -48,7 +47,7 @@ function getJoinResponsePayload(respondingNode, membershipList) {
     return {
         app: 'ringpop',
         coordinator:  responderHostPort,
-        membershipChecksum: checksum(membership),
+        membershipChecksum: checksumMethod(membership),
         membership: membership
     };
 }

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -326,4 +326,16 @@ TestCoordinator.prototype.getSUTHostPort = function getSUTHostPort() {
     return this.sutHostPort;
 };
 
+// There is an incompatibility in the way the checksum is calculated between ringpop-node and ringpop-go.
+// Also, the ringpop-node has two ways of hashing the checksum string.
+//
+// After the SUT is launched, it's admin/stats-endpoint is hit to get it's membership list and checksum so
+// the correct hashing method is determined by calculating and comparing a checksum based on it's membership
+// list with all three methods.
+// From that point onwards, the correct checksum method is used for calculating checksums in fake-node.
+TestCoordinator.prototype.checksum = function checksum() {
+    //default to no-checksum. This method is changed based on runtime data of the SUT
+    return null;
+};
+
 module.exports = TestCoordinator;

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -108,6 +108,7 @@ function testStateTransitions(ns, initial, newState, finalState, incNoDelta, sta
 function prepareCluster(insert_fns) {
     return function(t, tc, n) {
         return [
+            dsl.assertDetectChecksumMethod(t, tc),
             dsl.waitForJoins(t, tc, n),
             dsl.assertStats(t, tc, n+1, 0, 0),
             insert_fns(t, tc, n),


### PR DESCRIPTION
There is an incompatibility in the way the checksum is calculated between ringpop-node and ringpop-go. Also, the ringpop-node has two ways of hashing the checksum string.

After the SUT is launched, it's `admin/stats`-endpoint is hit to get it's membership list and checksum. Then the correct hashing method is determined by calculating and comparing a checksum based on it's membership list with all three methods. From that point onwards, the correct checksum method is used for calculating checksums in fake-node.

Tested against:
✅ ringpop-node#master
✅ ringpop-node#uber/menno/bi-dir-sync (with `--enable-feature bidirectional-full-syncs`)
✅ ringpop-go#master (with `--enable-feature bidirectional-full-syncs`)
✅ ringpop-go#dev (with `--enable-feature bidirectional-full-syncs`)

 and current dev of ringpop-go without issues. 