### PR TITLE
Add throttle test for bidirectional full syncs

### DIFF
--- a/test/bidir-full-sync-tests.js
+++ b/test/bidir-full-sync-tests.js
@@ -92,6 +92,7 @@ function overwriteJoinHandlerWithPause(tc, idx) {
         var fakeNode = tc.fakeNodes[idx];
 
         fakeNode.cachedJoins = [];
+        fakeNode.originalJoinHandler = fakeNode.endpoints['Join'].handler;
         fakeNode.endpoints['Join'].handler = function() {
             fakeNode.cachedJoins.push(arguments)
         };
@@ -147,12 +148,13 @@ function handleCachedJoinsAndRestoreJoinHandler(tc, idx) {
     return function handleCachedJoinsAndRestoreJoinHandler(list, cb) {
         var fakeNode = tc.fakeNodes[idx];
 
-        fakeNode.endpoints['Join'].handler = fakeNode.joinHandler;
+        var originalHandler = fakeNode.originalJoinHandler;
+        fakeNode.endpoints['Join'].handler = originalHandler;
 
         var cachedJoins = fakeNode.cachedJoins;
 
         for(var i=0; i< cachedJoins.length; i++) {
-            fakeNode.joinHandler.apply(fakeNode, cachedJoins[i]);
+            originalHandler.apply(fakeNode, cachedJoins[i]);
         }
 
         cb(list);

--- a/test/bidir-full-sync-tests.js
+++ b/test/bidir-full-sync-tests.js
@@ -48,74 +48,67 @@ test2('bidirectional full sync test', getClusterSizes(5), 20000,
 	})
 );
 
+// As a safety check, both the ringpop-go and ringpop-node limit the number
+// (defaults to 5) of concurrent bidirectional full syncs.
+//
+// A bidirectional full sync is triggered by a ping to a node without outstanding
+// membership changes where the checksum in the ping doesn't match the node's checksum.
+// This results in the node sending it's full membership. At the same time, the node
+// will send a join to the source of the ping request to get it's full membership list.
+//
+// This test pauses responding to the join request to make sure there are multiple
+// joins happening at the same time. If the throttling is working, there should
+// never be more than 5 joins in the queue.
 test2('bidirectional full sync throttling test', getClusterSizes(3), 20000,
     prepareCluster(function(t, tc, n) {
+        var numberOfFullSyncsToTrigger = Math.max(6, n*2);
+        var expectedJoins = 5;
         return [
             dsl.assertStats(t, tc, n+1, 0, 0),
             dsl.waitForEmptyPing(t, tc),
 
-            assertReverseFullSyncThrottling(t, tc, 0, n*3, 5),
+            //pause handling joins to stall reverse full syncs
+            overwriteJoinHandlerWithPause(tc, 0),
 
-            dsl.assertStats(t, tc, n+1, 0, 0),
+            // trigger the reverse full syncs
+            triggerReverseFullSyncs(tc, 0, numberOfFullSyncsToTrigger),
+
+            // verify the number of )cached) join requests
+            verifyCachedJoins(t, tc, 0, numberOfFullSyncsToTrigger, expectedJoins),
+
+            // handle the joins and restore the original join-handler.
+            handleCachedJoinsAndRestoreJoinHandler(tc, 0),
+
+            // wait for the joins to be handled.
+            dsl.waitForJoins(t, tc, expectedJoins),
+
+            dsl.assertStats(t, tc, n+1, 0, 0)
         ];
     })
 );
 
-// assert if the number of joins is throttled.
-function assertReverseFullSyncThrottling(t, tc, idx, count, expectedJoins) {
-    var functions = [];
-
-    //pause handling joins to stall reverse full syncs
-    functions.push(pauseHandlingJoins);
-    functions.push(dsl.waitForEmptyPing(t, tc));
-
-    // trigger the reverse full syncs
-    functions.push(triggerReverseFullSyncs(tc, idx, count));
-
-    // verify the number of join requests
-    functions.push(verify);
-
-    // handle the joins
-    functions.push(resumeHandlingJoins);
-
-    // the SUT sends a join request to perform a bidirectional full sync
-    functions.push(dsl.waitForJoins(t, tc, expectedJoins));
-
-    var joins = [];
-
-    return functions;
-
-    function triggerReverseFullSyncs(tc, nodeIx, count) {
-        var f = function triggerFullSync(list, cb) {
-            async.times(count, function triggerFullSync(i, next){
-                tc.fakeNodes[nodeIx].requestPing(next, undefined, {checksum: 1}); //override checksum to trigger a fullsync
-            }, function done() {
-                cb(list);
-            });
-        };
-        f.callerName = 'triggerReverseFullSyncs';
-
-        return f;
-    }
-
-    function pauseHandlingJoins(list, cb) {
+function overwriteJoinHandlerWithPause(tc, idx) {
+    return function overwriteJoinHandlerWithPause(list, cb) {
         var fakeNode = tc.fakeNodes[idx];
 
+        fakeNode.cachedJoins = [];
         fakeNode.endpoints['Join'].handler = function() {
-            console.log('handling join');
-            joins.push(arguments)
+            fakeNode.cachedJoins.push(arguments)
         };
-
 
         cb(list);
     }
+}
 
-    function verify(list, cb) {
-        if (joins.length < expectedJoins) {
+function verifyCachedJoins(t, tc, idx, fullSyncs, expectedJoins) {
+    return function verifyCachedJoins(list, cb) {
+        var fakeNode = tc.fakeNodes[idx];
+        var cachedJoins = fakeNode.cachedJoins;
+        if (cachedJoins.length < expectedJoins) {
             cb(null);
             return;
         }
-        t.equal(joins.length, expectedJoins);
+        t.equal(cachedJoins.length, expectedJoins);
 
         var pings = _.filter(list, {
             type: events.Types.Ping,
@@ -126,23 +119,40 @@ function assertReverseFullSyncThrottling(t, tc, idx, count, expectedJoins) {
             return event.receiver === tc.fakeNodes[idx].getHostPort();
         });
 
-        if (pings.length < count) {
+        if (pings.length < fullSyncs) {
             cb(null);
             return;
         }
 
-        t.equals(pings.length, count);
+        t.equals(pings.length, fullSyncs);
 
         cb(_.reject(list, {type: events.Types.Ping, direction: 'response'}));
     }
+}
 
-    function resumeHandlingJoins(list, cb) {
+function triggerReverseFullSyncs(tc, nodeIx, count) {
+    var f = function triggerFullSync(list, cb) {
+        async.times(count, function triggerFullSync(i, next){
+            tc.fakeNodes[nodeIx].requestPing(next, undefined, {checksum: 1}); //override checksum to trigger a fullsync
+        }, function done() {
+            cb(list);
+        });
+    };
+    f.callerName = 'triggerReverseFullSyncs';
+
+    return f;
+}
+
+function handleCachedJoinsAndRestoreJoinHandler(tc, idx) {
+    return function handleCachedJoinsAndRestoreJoinHandler(list, cb) {
         var fakeNode = tc.fakeNodes[idx];
 
         fakeNode.endpoints['Join'].handler = fakeNode.joinHandler;
 
-        for(var i=0; i< joins.length; i++) {
-            fakeNode.joinHandler.apply(fakeNode, joins[i]);
+        var cachedJoins = fakeNode.cachedJoins;
+
+        for(var i=0; i< cachedJoins.length; i++) {
+            fakeNode.joinHandler.apply(fakeNode, cachedJoins[i]);
         }
 
         cb(list);

--- a/test/fake-node.js
+++ b/test/fake-node.js
@@ -19,6 +19,8 @@
 // THE SOFTWARE.
 
 var TChannel = require('tchannel');
+var _ = require('lodash');
+
 var safeParse = require('./util').safeParse;
 var makeHostPort = require('./util').makeHostPort;
 var handleJoin = require('./protocol-join').handleJoin;
@@ -204,7 +206,7 @@ FakeNode.prototype.requestJoin = function requestJoin(callback) {
     });
 };
 
-FakeNode.prototype.requestPing = function requestPing(callback, piggybackData) {
+FakeNode.prototype.requestPing = function requestPing(callback, piggybackData, bodyOverrides) {
     var self = this;
 
     var changes = [];
@@ -212,12 +214,13 @@ FakeNode.prototype.requestPing = function requestPing(callback, piggybackData) {
         changes.push(piggybackData);
     }
 
-    var body = JSON.stringify({
+    var bodyObject = {
         source: self.getHostPort(),
         checksum: self.coordinator.checksum(self.coordinator.getMembership()),
         changes: changes,
         sourceIncarnationNumber: self.incarnationNumber,
-    });
+    };
+    var body = JSON.stringify(_.extend(bodyObject, bodyOverrides));
 
 
     self.channel.waitForIdentified({

--- a/test/fake-node.js
+++ b/test/fake-node.js
@@ -206,6 +206,15 @@ FakeNode.prototype.requestJoin = function requestJoin(callback) {
     });
 };
 
+/**
+ * Make a ping request to the SUT.
+ *
+ * @param {function} callback The callback to call after receiving the response of the ping-request.
+ *  It's signature matches the TChannel callback (err, res, arg2, arg3).
+ * @param {object} piggybackData The changes to piggy back on the ping.
+ * @param {object} bodyOverrides Overwrite specific ping body parameters (checksum, source, sourceIncarnationNumber, changes)
+ * @returns {Function} Returns the function that'll be invoked when running the integration test.
+ */
 FakeNode.prototype.requestPing = function requestPing(callback, piggybackData, bodyOverrides) {
     var self = this;
 

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -224,13 +224,13 @@ function changeStatus(t, tc, sourceIx, subjectIx, status, subjectIncNoDelta) {
     return f;
 }
 
-function sendPing(t, tc, nodeIx, piggybackOpts) {
+function sendPing(t, tc, nodeIx, piggybackOpts, bodyOverrides) {
     var f = _.once(function sendPing(list, cb) {
         var piggybackData = piggyback(tc, piggybackOpts);
 
         tc.fakeNodes[nodeIx].requestPing(function() {
             cb(list);
-        }, piggybackData);
+        }, piggybackData, bodyOverrides);
     });
     f.callerName = 'sendPing';
     return f;

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -224,6 +224,16 @@ function changeStatus(t, tc, sourceIx, subjectIx, status, subjectIncNoDelta) {
     return f;
 }
 
+/**
+ * Send a ping to the SUT from a fake node
+ *
+ * @param {Test} t The current running test
+ * @param {TestCoordinator} tc The test coordinator.
+ * @param {number} nodeIx The index of the fakeNode that should send the ping.
+ * @param {object} piggybackOpts The changes to piggy back on the ping.
+ * @param {object} bodyOverrides Overwrite specific ping body parameters (checksum, source, sourceIncarnationNumber, changes)
+ * @returns {Function} Returns the function that'll be invoked when running the integration test.
+ */
 function sendPing(t, tc, nodeIx, piggybackOpts, bodyOverrides) {
     var f = _.once(function sendPing(list, cb) {
         var piggybackData = piggyback(tc, piggybackOpts);


### PR DESCRIPTION
As a safety check, both the ringpop-go and ringpop-node limit the number (defaults to 5) of concurrent bidirectional full syncs. 
A bidirectional full sync is triggered by a ping to a node without outstanding membership changes where the checksum in the ping doesn't match the node's checksum. This results in the node sending it's full membership. At the same time, the node will send a join to the source of the ping request to get it's full membership list.
This test pauses responding to the join request to make sure there are multiple joins happening at the same time. If the throttling is working, there should never be more than 5 joins in the queue.