### PR TITLE
Remove references to deprecated admin/reload-endpoint

### DIFF
--- a/test/admin-tests.js
+++ b/test/admin-tests.js
@@ -27,8 +27,6 @@ var getClusterSizes = require('./it-tests').getClusterSizes;
 // TODO endpoints
 //   /admin/debugClear (NOOP in go, toggle between ping logs in node2)
 //   /admin/debugSet
-// node only:
-//   /admin/reload
 
 test2('endpoint: /admin/gossip/stop', getClusterSizes(), 5000, prepareCluster(function(t,tc,n) {
     return [

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -740,7 +740,6 @@ function createValidateEvent(t, tc) {
     // /admin/gossip
     // /admin/join
     // /admin/leave
-    // /admin/reload
     // /admin/tick
 
     return function validateIncommingEvent(event) {


### PR DESCRIPTION
uber/ringpop-node#255 deprecates the `admin/reload`-endpoint. This PR removes all references to it.