### PR TITLE
Speed up integration tests; 10:18 to 3:12 minutes

### DIFF
--- a/test/admin-tests.js
+++ b/test/admin-tests.js
@@ -131,7 +131,7 @@ test2('endpoint: /admin/stats', getClusterSizes(), 5000, prepareCluster(function
 test2('endpoint: /admin/member/leave', getClusterSizes(), 10000, prepareCluster(function(t, tc, n) {
     return [
         // this makes testing the piggy backed status easier
-        dsl.waitForEmptyPing(t, tc),
+        dsl.drainDisseminator(t, tc),
 
         // instruct node to leave cluster
         dsl.callEndpoint(t, tc, '/admin/member/leave'),
@@ -160,7 +160,7 @@ test2('endpoint: /admin/member/leave', getClusterSizes(), 10000, prepareCluster(
 test2('endpoint: /admin/member/join', getClusterSizes(), 10000, prepareCluster(function(t, tc, n) {
     return [
         // this makes testing the piggy backed status easier
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         // instruct node to leave cluster
         dsl.callEndpoint(t, tc, '/admin/member/leave'),

--- a/test/bidir-full-sync-tests.js
+++ b/test/bidir-full-sync-tests.js
@@ -31,7 +31,7 @@ test2('bidirectional full sync test', getClusterSizes(5), 20000,
     prepareCluster(function(t, tc, n) {
 	    return [
             dsl.assertStats(t, tc, n+1, 0, 0),
-            dsl.waitForEmptyPing(t, tc),
+            dsl.drainDisseminator(t, tc),
 
             // create faulties so that the membership of the faulty nodes is
             // out of sync with the membership of the SUT
@@ -65,7 +65,7 @@ test2('bidirectional full sync throttling test', getClusterSizes(3), 20000,
         var expectedJoins = 5;
         return [
             dsl.assertStats(t, tc, n+1, 0, 0),
-            dsl.waitForEmptyPing(t, tc),
+            dsl.drainDisseminator(t, tc),
 
             assertReverseFullSyncThrottling(t, tc, 0, numberOfFullSyncsToTrigger, expectedJoins),
 

--- a/test/piggyback-tests.js
+++ b/test/piggyback-tests.js
@@ -28,7 +28,7 @@ var getClusterSizes = require('./it-tests').getClusterSizes;
 test2('ringpop sends piggyback info in ping request', getClusterSizes(3), 20000, prepareCluster(function(t, tc, n) {
     return [
         // TODO clear the dissemination information from the SUT by flooding it with pings instead of waiting for it
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         dsl.changeStatus(t, tc, 0, 1, 'suspect'),
         dsl.waitForPingResponse(t, tc, 0),
@@ -51,7 +51,7 @@ test2('ringpop sends piggyback info in ping request', getClusterSizes(3), 20000,
 test2('ringpop updates its dissimination list on pingreq', getClusterSizes(3), 20000, prepareCluster(function(t, tc, n) {
     return [
         // TODO clear the dissemination information from the SUT by flooding it with pings instead of waiting for it
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         // send information to be piggy backed via pingreq
         dsl.sendPingReq(t, tc, 0, 2, {
@@ -79,7 +79,7 @@ test2('ringpop updates its dissimination list on pingreq', getClusterSizes(3), 2
 test2('ringpop sends piggyback info in ping-req response', getClusterSizes(3), 20000, prepareCluster(function(t, tc, n) {
     return [
         // TODO clear the dissemination information from the SUT by flooding it with pings instead of waiting for it
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         // send information to be piggy backed
         dsl.changeStatus(t, tc, 0, 1, 'suspect'),
@@ -109,7 +109,7 @@ test2('ringpop sends piggyback info in ping-req response', getClusterSizes(3), 2
 test2('ringpop piggybacking decays', getClusterSizes(3), 40000, prepareCluster(function(t, tc, n) {
     return [
         // TODO clear the dissemination information from the SUT by flooding it with pings instead of waiting for it
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         // send information to be piggy backed
         dsl.changeStatus(t, tc, 1, 2, 'suspect'),
@@ -117,14 +117,14 @@ test2('ringpop piggybacking decays', getClusterSizes(3), 40000, prepareCluster(f
 
         // if the SUT decays the updates it will start pinging with 0 updates at some point
         // TODO do this with a set number of pings to the SUT to speed up the test
-        dsl.waitForEmptyPing(t, tc)
+        dsl.drainDisseminator(t, tc)
     ];
 }));
 
 test2('ringpop piggybacking should ignore updates when it already knows about', getClusterSizes(3), 20000, prepareCluster(function(t, tc, n) {
     return [
         // TODO clear the dissemination information from the SUT by flooding it with pings instead of waiting for it
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         // send information that is already known to the SUT
         dsl.changeStatus(t, tc, 0, 1, 'alive'),
@@ -146,7 +146,7 @@ test2('ringpop piggybacking should ignore updates when it already knows about', 
 test2('ringpop sends piggyback info in ping response', getClusterSizes(3), 20000, prepareCluster(function(t, tc, n) {
     return [
         // TODO clear the dissemination information from the SUT by flooding it with pings instead of waiting for it
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         // send information to be piggy backed
         dsl.changeStatus(t, tc, 0, 1, 'suspect'),
@@ -171,7 +171,7 @@ test2('ringpop sends piggyback info in ping response', getClusterSizes(3), 20000
 test2('ringpop sends piggyback info in ping-req request', getClusterSizes(3), 20000, prepareCluster(function(t, tc, n) {
     return [
         // TODO clear the dissemination information from the SUT by flooding it with pings instead of waiting for it
-        dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
+        dsl.drainDisseminator(t, tc), // problem is that if decay is not working you might never get to this point
 
         // send information to be piggy backed
         dsl.changeStatus(t, tc, 0, 1, 'suspect'),

--- a/test/piggyback-tests.js
+++ b/test/piggyback-tests.js
@@ -112,8 +112,8 @@ test2('ringpop piggybacking decays', getClusterSizes(3), 40000, prepareCluster(f
         dsl.waitForEmptyPing(t, tc), // problem is that if decay is not working you might never get to this point
 
         // send information to be piggy backed
-        dsl.changeStatus(t, tc, 0, 1, 'suspect'),
-        dsl.waitForPingResponse(t, tc, 0),
+        dsl.changeStatus(t, tc, 1, 2, 'suspect'),
+        dsl.waitForPingResponse(t, tc, 1),
 
         // if the SUT decays the updates it will start pinging with 0 updates at some point
         // TODO do this with a set number of pings to the SUT to speed up the test

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -926,7 +926,6 @@ module.exports = {
     waitForPing: waitForPing,
 
     // waitForEmptyPing is slow. If possible, use drainDisseminator instead.
-    // waitForEmptyPing: waitForEmptyPing,
     drainDisseminator: drainDisseminator,
 
     validateEventBody: validateEventBody,

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -92,6 +92,15 @@ function waitForPing(t, tc) {
     };
 }
 
+function fasterWaitForEmptyPing(t, tc) {
+    // waitForEmptyPing(t, tc);
+    return [
+        sendPings(t, tc, _.times(30, _.constant(0))),
+        waitForPingResponses(t, tc, _.times(30, _.constant(0))),
+        waitForEmptyPing(t, tc),
+    ];
+}
+
 function waitForEmptyPing(t, tc) {
     // Waits for a ping with an empty changes list, and consumes all pings with changes in them
     // usefull to wait for a 'stable' SUT before doing piggyback tests. Given that decay works in the SUT
@@ -224,16 +233,11 @@ function changeStatus(t, tc, sourceIx, subjectIx, status, subjectIncNoDelta) {
     return f;
 }
 
-/**
- * Send a ping to the SUT from a fake node
- *
- * @param {Test} t The current running test
- * @param {TestCoordinator} tc The test coordinator.
- * @param {number} nodeIx The index of the fakeNode that should send the ping.
- * @param {object} piggybackOpts The changes to piggy back on the ping.
- * @param {object} bodyOverrides Overwrite specific ping body parameters (checksum, source, sourceIncarnationNumber, changes)
- * @returns {Function} Returns the function that'll be invoked when running the integration test.
- */
+
+// Send a ping to the SUT from a fake node, where:
+// - nodeIx is the index of the fakeNode that should send the ping.
+// - piggybackOpts are the changes to piggy back on the ping.
+// - bodyOverrides overwrite specific ping body parameters (checksum, source, sourceIncarnationNumber, changes)
 function sendPing(t, tc, nodeIx, piggybackOpts, bodyOverrides) {
     var f = _.once(function sendPing(list, cb) {
         var piggybackData = piggyback(tc, piggybackOpts);
@@ -910,8 +914,9 @@ module.exports = {
     waitForJoins: waitForJoins,
     waitForPingReqs: waitForPingReqs,
     waitForPing: waitForPing,
-    waitForEmptyPing: waitForEmptyPing,
-    // drainSUTDissemination: drainSUTDissemination,
+    // waitForEmptyPing: waitForEmptyPing,
+    waitForEmptyPing: fasterWaitForEmptyPing,
+
     validateEventBody: validateEventBody,
 
     callEndpoint: callEndpoint,


### PR DESCRIPTION
Before waiting for the disseminator of the real node to drain we send it 30 pings (this will certainly drain it immediately). That means we no longer have to wait 6 seconds for the disseminator to drain every waitForEmptyPing is called.

It is certainly not the cleanest implementation but I really do not want to spent a lot of time on this.

The speedup in from 10:18 to 3:12 minutes. Thats a speedup of **3.2x**.