### PR TITLE
Mark bidirectional-full-syncs as mandatory

### DIFF
--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -75,6 +75,7 @@ var features = {
         ]
     },
     'bidirectional-full-syncs': {
+        mandatory: true,
         tests: [
             './bidir-full-sync-tests'
         ]


### PR DESCRIPTION
Because uber/ringpop-node#251 added bidirectional full syncs in ringpop-node, this test should be mandatory moving forward.