### PR TITLE
Verify if source-field of changes is not triggering a reverse full-sync

### DIFF
--- a/test/partition-healing-tests.js
+++ b/test/partition-healing-tests.js
@@ -370,6 +370,11 @@ test2('dont\'t merge partitions when B is not fully reincarnated', [3], 20000, p
                 return false;
             }
 
+            if (_.filter(ping.body.changes, {source: tc.sutHostPort}).length !== 0) {
+                t.fail("expected the source address to be different to prevent a bi-directional full sync");
+                return;
+            }
+
             return true;
         }),
 


### PR DESCRIPTION
During partition healing the changes send to target of the heal-operation are constructed in such a way that unmerge-able nodes in the memberships are marked as suspect so they will reincarnate. If the source of those changes is equal to the host-port of the node triggering the heal-operation, this could trigger a reverse full-sync. The reverse full-sync subsequently could result in a state where the two partitions start communicating before all the unmerge-able nodes are reincarnated. This would result in a lot of unnecessary gossiping.