### PR TITLE
Add heal-stats to running_ringpop.md#monitoring

### DIFF
--- a/docs/running_ringpop.md
+++ b/docs/running_ringpop.md
@@ -66,6 +66,8 @@ that Ringpop emits:
 |dissemination.bump-bypass|Number of times piggyback count is preserved after failed ping or ping-req|count
 |filtered-change|A change to be disseminated was deduped|count
 |full-sync|Number of full syncs transmitted|count
+|heal.triggered.discover_provider|Number of times the partition healing is initiated using the discover provider. Note: this stat will be emitted even if there is no faulty or unknown target found; the actual number of heal attempts can be measured using `heal.attempt`.|count
+|heal.attempt|Number of times a heal opeartion is performed to a target-node|count
 |join|Time required to complete join process successfully|timer
 |join.complete|Join process completed successfully|count
 |join.failed.destroyed|Join process failed because Ringpop had been destroyed|count


### PR DESCRIPTION
Add the emitted stats during partition healing to the list with emitted stats.