### PR TITLE
Fix a flappy reaping-faulty-nodes test

### DIFF
--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -218,9 +218,10 @@ test2('tombstone should be gossiped with flag when applied as state', getCluster
             dsl.consumePings(t, tc),
 
             // Wait for a ping from the SUT and validate that it does not gossip about the tombstone
-            dsl.validateEventBody(t, tc, {
-                type: events.Types.Ping,
-                direction: 'request'
+            dsl.validateEventBody(t, tc, function(ping) {
+                return ping.type === events.Types.Ping
+                    && ping.direction === 'request'
+                    && ping.body.changes[0].status !== 'alive'
             }, "The gossip should contain a flagged tombstone", function (ping) {
                 return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
                     && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;
@@ -264,9 +265,10 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
             dsl.consumePings(t, tc),
 
             // Wait for a ping from the SUT and validate that it does not gossip about the tombstone
-            dsl.validateEventBody(t, tc, {
-                type: events.Types.Ping,
-                direction: 'request'
+            dsl.validateEventBody(t, tc, function(ping) {
+                return ping.type === events.Types.Ping
+                    && ping.direction === 'request'
+                    && ping.body.changes[0].status !== 'alive'
             }, "The gossip should contain a flagged tombstone", function (ping) {
                 return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
                     && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -222,10 +222,16 @@ test2('tombstone should be gossiped with flag when applied as state', getCluster
             // Since we pinged SUT from nodeIx=0, the node filters that
             // changes, therefore the conditional to skip it's ping request
             // below.
+            //
+            // We also ignore ping requests that gossip 'alive' status.
+            // That can happen because, at least in ringpop-node, a ping request
+            // before disseminator update could have been executed after the ping
+            // response above is sent over the wire.
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'
-                    && ping.receiver !== tc.fakeNodes[0].getHostPort()
+                    && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
+                    && ping.body.changes[0].status !== 'alive'  // ignore old ping
             }, "The gossip should contain a flagged tombstone", function (ping) {
                 return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
                     && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;
@@ -273,10 +279,16 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
             // Since we pinged SUT from nodeIx=0, the node filters that
             // changes, therefore the conditional to skip it's ping request
             // below.
+            //
+            // We also ignore ping requests that gossip 'alive' status.
+            // That can happen because, at least in ringpop-node, a ping request
+            // before disseminator update could have been executed after the ping
+            // response above is sent over the wire.
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'
-                    && ping.receiver !== tc.fakeNodes[0].getHostPort()
+                    && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
+                    && ping.body.changes[0].status !== 'alive'  // ignore old ping
             }, "The gossip should contain a flagged tombstone", function (ping) {
                 return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
                     && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -217,25 +217,8 @@ test2('tombstone should be gossiped with flag when applied as state', getCluster
             // clear all pings that happened before we gossiped the tombstone
             dsl.consumePings(t, tc),
 
-            // Wait for a ping from the SUT and validate that it does not gossip about the tombstone.
-            //
-            // Since we pinged SUT from nodeIx=0, the node filters that
-            // changes, therefore the conditional to skip it's ping request
-            // below.
-            //
-            // We also ignore ping requests that gossip 'alive' status.
-            // That can happen because, at least in ringpop-node, a ping request
-            // before disseminator update could have been executed after the ping
-            // response above is sent over the wire.
-            dsl.validateEventBody(t, tc, function(ping) {
-                return ping.type === events.Types.Ping
-                    && ping.direction === 'request'
-                    && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
-                    && ping.body.changes[0].status !== 'alive'  // ignore old ping
-            }, "The gossip should contain a flagged tombstone", function (ping) {
-                return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
-                    && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;
-            }),
+            // Wait for a ping with tombstone, see function doc.
+            pingNotTombstoneState(t, tc)
         ];
     })
 );
@@ -274,25 +257,30 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
             // clear all pings that happened before we gossiped the tombstone
             dsl.consumePings(t, tc),
 
-            // Wait for a ping from the SUT and validate that it does not gossip about the tombstone
-            //
-            // Since we pinged SUT from nodeIx=0, the node filters that
-            // changes, therefore the conditional to skip it's ping request
-            // below.
-            //
-            // We also ignore ping requests that gossip 'alive' status.
-            // That can happen because, at least in ringpop-node, a ping request
-            // before disseminator update could have been executed after the ping
-            // response above is sent over the wire.
-            dsl.validateEventBody(t, tc, function(ping) {
-                return ping.type === events.Types.Ping
-                    && ping.direction === 'request'
-                    && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
-                    && ping.body.changes[0].status !== 'alive'  // ignore old ping
-            }, "The gossip should contain a flagged tombstone", function (ping) {
-                return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
-                    && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;
-            }),
+            // Wait for a ping with tombstone, see function doc.
+            pingNotTombstoneState(t, tc)
         ];
     })
 );
+
+// Wait for a ping from the SUT and validate that it does not gossip about the
+// tombstone as a state.
+//
+// Since we pinged SUT from nodeIx=0, the node filters that changes, therefore
+// the conditional to skip it's ping request below.
+//
+// We also ignore ping requests that gossip 'alive' status.  That can happen
+// because, at least in ringpop-node, a ping request before disseminator update
+// could have been executed after the ping response above is sent over the
+// wire.
+function pingNotTombstoneState(t, tc) {
+    return dsl.validateEventBody(t, tc, function(ping) {
+        return ping.type === events.Types.Ping
+            && ping.direction === 'request'
+            && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
+            && ping.body.changes[0].status !== 'alive'  // ignore old ping
+    }, "The gossip should contain a flagged tombstone", function (ping) {
+        return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
+            && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;
+    })
+}

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -219,8 +219,9 @@ test2('tombstone should be gossiped with flag when applied as state', getCluster
 
             // Wait for a ping from the SUT and validate that it does not gossip about the tombstone.
             //
-            // Since we pinged nodeIx=0, the node filters that changes, therefore the conditional
-            // to skip it's ping request below.
+            // Since we pinged SUT from nodeIx=0, the node filters that
+            // changes, therefore the conditional to skip it's ping request
+            // below.
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'
@@ -269,8 +270,9 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
 
             // Wait for a ping from the SUT and validate that it does not gossip about the tombstone
             //
-            // Since we pinged nodeIx=0, the node filters that changes, therefore the conditional
-            // to skip it's ping request below.
+            // Since we pinged SUT from nodeIx=0, the node filters that
+            // changes, therefore the conditional to skip it's ping request
+            // below.
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -217,7 +217,10 @@ test2('tombstone should be gossiped with flag when applied as state', getCluster
             // clear all pings that happened before we gossiped the tombstone
             dsl.consumePings(t, tc),
 
-            // Wait for a ping from the SUT and validate that it does not gossip about the tombstone
+            // Wait for a ping from the SUT and validate that it does not gossip about the tombstone.
+            //
+            // Since we pinged nodeIx=0, the node filters that changes, therefore the conditional
+            // to skip it's ping request below.
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'
@@ -265,6 +268,9 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
             dsl.consumePings(t, tc),
 
             // Wait for a ping from the SUT and validate that it does not gossip about the tombstone
+            //
+            // Since we pinged nodeIx=0, the node filters that changes, therefore the conditional
+            // to skip it's ping request below.
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -204,7 +204,7 @@ test2('tombstone should be applied when sent as a state', getClusterSizes(2), 20
     })
 );
 
-test2('tombstone should be gossiped with flag when applied as state', getClusterSizes(2), 20000,
+test2('tombstone should be gossiped with flag when applied as state', getClusterSizes(3), 20000,
     prepareCluster(function(t, tc, n) {
         return [
             dsl.sendPing(t, tc, 0, {
@@ -221,7 +221,7 @@ test2('tombstone should be gossiped with flag when applied as state', getCluster
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'
-                    && ping.body.changes[0].status !== 'alive'
+                    && ping.receiver !== tc.fakeNodes[0].getHostPort()
             }, "The gossip should contain a flagged tombstone", function (ping) {
                 return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
                     && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;
@@ -250,7 +250,7 @@ test2('tombstone should be applied when sent as a flag', getClusterSizes(2), 200
     })
 );
 
-test2('tombstone should be gossiped with flag when applied as a flag', getClusterSizes(2), 20000,
+test2('tombstone should be gossiped with flag when applied as a flag', getClusterSizes(3), 20000,
     prepareCluster(function(t, tc, n) {
         return [
             dsl.sendPing(t, tc, 0, {
@@ -268,7 +268,7 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
             dsl.validateEventBody(t, tc, function(ping) {
                 return ping.type === events.Types.Ping
                     && ping.direction === 'request'
-                    && ping.body.changes[0].status !== 'alive'
+                    && ping.receiver !== tc.fakeNodes[0].getHostPort()
             }, "The gossip should contain a flagged tombstone", function (ping) {
                 return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
                     && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;


### PR DESCRIPTION
It is not uncommon for SUT to ping an unrelated node with itself saying
"I'm alive". In this test, we need to ignore these pings. The case is
best reproduced with an overloaded system with n > 10. Example output:

    not ok 4979 The gossip should contain a flagged

      ---
        operator: ok
        expected: true
        actual:   false
        at: Array.validateEventBody [as 8]
    op-node/test/ringpop-common/test/ringpop-assert.js:147:11)
      ...
    ============== error details ===============

    {
      "body": {
        "checksum": 3250656653,
        "changes": [
          {
            "id": "6768c914-06e1-4122-8d00-0a2648f7f86d",
            "address": "127.0.0.1:24935",
            "status": "alive",
            "incarnationNumber": 1464253153302
          }
        ],
        "source": "127.0.0.1:24935",
        "sourceIncarnationNumber": 1464253153302
      }
    }

    ============================================
