### PR TITLE
Expose hostport information on failed test

### DIFF
--- a/test/test-util.js
+++ b/test/test-util.js
@@ -41,6 +41,14 @@ function test(msg, opts, cb) {
             console.log();
             console.log('============================================');
             console.log();
+            if(t._tc) {
+                console.log('============== node index : hostport ===============');
+                console.log("sut: "+ t._tc.sutHostPort);
+                t._tc.fakeNodes.forEach(function(fakeNode, i) {
+                    console.log(i + " => " + fakeNode.host + ":" + fakeNode.port);
+                });
+                console.log('====================================================');
+            }
         }
     });
 }
@@ -63,6 +71,7 @@ function test2(str, ns, deadline, init, callback) {
                 },
                 numNodes: n,
             });
+            t._tc = tc;
 
             init(t, tc, function onInit() {
                 tc.start(function onTCStarted() {


### PR DESCRIPTION
Expose hostport information on failed test

This will allow us to troubleshoot what messages came from which nodes
in error detail page.

Example output of the test I am currently working on, with this
information enabled:

    not ok 68 The gossip should contain a flagged tombstone
      ---
        operator: ok
        expected: true
        actual:   false
        at: Array.validateEventBody [as 8] (/home/uber/ringpop-node/test/ringpop-common/test/ringpop-assert.js:147:11)
      ...
    ============== error details ===============

    {
      "body": {
        "checksum": 702129473,
        "changes": [
          {
            "id": "79b38878-3003-4d1c-ae3f-5a3637e4c819",
            "address": "127.0.0.1:10489",
            "status": "alive",
            "incarnationNumber": 1464336701877
          }
        ],
        "source": "127.0.0.1:10489",
        "sourceIncarnationNumber": 1464336701877
      }
    }

    ============================================

    ============== node index : hostport ===============
    sut: 127.0.0.1:10489
    0 => 127.0.0.1:30193
    1 => 127.0.0.1:57251
    2 => 127.0.0.1:39071
    3 => 127.0.0.1:43446
    ====================================================
