### PR TITLE
Update tick-cluster to be in sync with ringpop-node version

### DIFF
--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -243,6 +243,11 @@ function debugClear() {
     });
 }
 
+function shutdown() {
+    killAllProcs();
+    process.exit();
+}
+
 var state = 'top';
 var func = null;
 var numArgRe = /^[1-9]$/;
@@ -252,8 +257,7 @@ function onData(char) {
         switch (char) {
             case '\u0003': // watch for control-c explicitly, because we are in raw-mode
             case 'q':
-                killAllProcs();
-                process.exit();
+                shutdown();
                 break;
             case 't':
                 tickAll();
@@ -480,6 +484,9 @@ function startCluster() {
 
 function main() {
     logMsg('init', color.cyan('tick-cluster started'));
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
 
     if (bindInterface) {
         localIP = bindInterface;

--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -29,7 +29,7 @@ var program = require('commander');
 var TChannel = require('tchannel');
 var fs = require('fs');
 
-var programInterpreter, programPath, procsToStart = 5;
+var programInterpreter, programPath, startingPort, bindInterface, procsToStart = 5;
 var hosts, procs, ringPool, localIP, toSuspend, toKill, tchannel; // defined later
 
 /* jshint maxparams: 6 */
@@ -471,31 +471,40 @@ function killAllProcs() {
 }
 
 function startCluster() {
-    var port = 3000;
     procs = []; // note module scope
     for (var i = 0; i < procsToStart ; i++) {
-        procs[i] = new ClusterProc(port + i);
+        procs[i] = new ClusterProc(startingPort + i);
     }
     logMsg('init', color.cyan('started ' + procsToStart + ' procs: ') + color.green(procs.map(function (p) { return p.proc.pid; }).join(', ')));
 }
 
 function main() {
-    logMsg('init', color.cyan('tick-cluster started ') + color.red('d: debug flags, g: gossip, j: join, k: kill, K: revive all, l: sleep, p: protocol stats, q: quit, s: cluster stats, t: tick'));
+    logMsg('init', color.cyan('tick-cluster started'));
 
-    findLocalIP();
-    hosts = generateHosts(localIP, 3000, procsToStart, 'hosts.json');
+    if (bindInterface) {
+        localIP = bindInterface;
+    } else {
+        findLocalIP();
+    }
+    hosts = generateHosts(localIP, startingPort, procsToStart, 'hosts.json');
     startCluster();
 
-    tchannel = new TChannel({host: "127.0.0.1", port: 2999});
+    tchannel = new TChannel({host: "127.0.0.1", port: startingPort + procsToStart + 1});
     ringPool = tchannel.makeSubChannel({
-        serviceName: 'tick-cluster'
+        serviceName: 'tick-cluster',
+	trace: false
     });
 
-    var stdin = process.stdin;
-    stdin.setRawMode(true);
-    stdin.resume();
-    stdin.setEncoding('utf8');
-    stdin.on('data', onData);
+    try {
+        var stdin = process.stdin;
+        stdin.setRawMode(true);
+        stdin.resume();
+        stdin.setEncoding('utf8');
+        stdin.on('data', onData);
+        logMsg('init', color.red('d: debug flags, g: gossip, j: join, k: kill, K: revive all, l: sleep, p: protocol stats, q: quit, s: cluster stats, t: tick'));
+    } catch (e) {
+        logMsg('init', 'Unable to open stdin; interactive commands disabled');
+    }
 }
 
 function displayMenu(logFn) {
@@ -553,7 +562,9 @@ function send(host, arg1, arg2, arg3, callback) {
 program
     .version(require('../package.json').version)
     .option('-n <size>', 'Size of cluster. Default is ' + procsToStart + '.')
-    .option('-i, --interpreter <interpreter>', 'Interpreter that runs program.')
+    .option('-i, --interpreter <interpreter>', 'Interpreter that runs program. Usually `node`.')
+    .option('--interface <address>', 'Interface to bind ringpop instances to.')
+    .option('--port <num>', 'Starting port for instances.')
     .arguments('<program>')
     .description('tick-cluster is a tool that launches a ringpop cluster of arbitrary size')
     .action(function onAction(path, options) {
@@ -566,6 +577,8 @@ program
             procsToStart = parseInt(options.N);
         }
         programInterpreter = options.interpreter;
+        bindInterface = options.interface;
+        startingPort = parseInt(options.port);
     });
 
 program.on('--help', function onHelp() {
@@ -589,6 +602,10 @@ if (!fs.existsSync(programPath)) {
 if (isNaN(procsToStart)) {
     console.error('Error: number of processes to start is not an integer');
     process.exit(1);
+}
+
+if (isNaN(startingPort)) {
+    startingPort = 3000;
 }
 
 main();


### PR DESCRIPTION
There were some changes added to ringpop-node version of tick-cluster, which is used in ringpop-admin tests. We want to have only one version of tick-cluster that should leave in ringpop-common. This PR is to put ringpop-common version in sync with ringpop-node.