### PR TITLE
Fix failing integration test

### DIFF
--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -278,7 +278,7 @@ function pingNotTombstoneState(t, tc) {
         return ping.type === events.Types.Ping
             && ping.direction === 'request'
             && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
-            && ! (ping.body.changes && ping.body.changes[0].status === 'alive')
+            && ! (ping.body.changes[0] && ping.body.changes[0].status === 'alive')
     }, "The gossip should contain a flagged tombstone", function (ping) {
         return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
             && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -278,7 +278,8 @@ function pingNotTombstoneState(t, tc) {
         return ping.type === events.Types.Ping
             && ping.direction === 'request'
             && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
-            && ! (ping.body.changes[0] && ping.body.changes[0].status === 'alive')
+            && ping.body.changes[0] // nodeIx=0 sends an empty change list
+            && ping.body.changes[0].status !== 'alive' // race described above
     }, "The gossip should contain a flagged tombstone", function (ping) {
         return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
             && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -278,7 +278,7 @@ function pingNotTombstoneState(t, tc) {
         return ping.type === events.Types.Ping
             && ping.direction === 'request'
             && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
-            && ping.body.changes[0].status !== 'alive'  // ignore old ping
+            && ! (ping.body.changes && ping.body.changes[0].status === 'alive')
     }, "The gossip should contain a flagged tombstone", function (ping) {
         return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
             && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -258,7 +258,7 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
 );
 
 // Wait for a ping from the SUT and validate that it does not gossip about the
-// tombstone as a state (rather, as a flag)
+// tombstone as a state, but does gossip as a flag.
 //
 // Since we pinged SUT from nodeIx=0, the node filters that changes, therefore
 // the conditional to skip it's ping request below.

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -214,9 +214,6 @@ test2('tombstone should be gossiped with flag when applied as state', getCluster
             }),
             dsl.waitForPingResponse(t, tc, 0),
 
-            // clear all pings that happened before we gossiped the tombstone
-            dsl.consumePings(t, tc),
-
             // Wait for a ping with tombstone, see function doc.
             pingNotTombstoneState(t, tc)
         ];
@@ -254,9 +251,6 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
             }),
             dsl.waitForPingResponse(t, tc, 0),
 
-            // clear all pings that happened before we gossiped the tombstone
-            dsl.consumePings(t, tc),
-
             // Wait for a ping with tombstone, see function doc.
             pingNotTombstoneState(t, tc)
         ];
@@ -264,7 +258,7 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
 );
 
 // Wait for a ping from the SUT and validate that it does not gossip about the
-// tombstone as a state.
+// tombstone as a state (rather, as a flag)
 //
 // Since we pinged SUT from nodeIx=0, the node filters that changes, therefore
 // the conditional to skip it's ping request below.
@@ -274,12 +268,17 @@ test2('tombstone should be gossiped with flag when applied as a flag', getCluste
 // could have been executed after the ping response above is sent over the
 // wire.
 function pingNotTombstoneState(t, tc) {
+    // Checks if a given ping contains a single 'alive' message
+    function isASingleAliveMessage(ping) {
+        return ping.body.changes.length == 1
+            && ping.body.changes[0].status === 'alive'
+    }
+
     return dsl.validateEventBody(t, tc, function(ping) {
         return ping.type === events.Types.Ping
             && ping.direction === 'request'
             && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
-            && ping.body.changes[0] // nodeIx=0 sends an empty change list
-            && ping.body.changes[0].status !== 'alive' // race described above
+            && ! isASingleAliveMessage(ping) // race in ringpop-node, described above
     }, "The gossip should contain a flagged tombstone", function (ping) {
         return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
             && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -278,7 +278,7 @@ function pingNotTombstoneState(t, tc) {
         return ping.type === events.Types.Ping
             && ping.direction === 'request'
             && ping.receiver !== tc.fakeNodes[0].getHostPort() // ignore nodeIx=0
-            && ! isASingleAliveMessage(ping) // race in ringpop-node, described above
+            && !isASingleAliveMessage(ping) // race in ringpop-node, described above
     }, "The gossip should contain a flagged tombstone", function (ping) {
         return _.filter(ping.body.changes, { status: 'faulty', tombstone: true }).length === 1
             && _.filter(ping.body.changes, { status: 'tombstone' }).length === 0;


### PR DESCRIPTION
A ping might not even have 'changes' array, add a check for it.

Example:

    ringpop-common/test/reaping-faulty-nodes.js:281
                && ping.body.changes[0].status !== 'alive'  // ignore old ping
                                       ^
    TypeError: Cannot read property 'status' of undefined
        at dsl.validateEventBody._.filter.status (ringpop-common/test/reaping-faulty-nodes.js:281:36)
        at baseFindIndex (ringpop-common/test/node_modules/lodash/index.js:326:11)
        at Function.findIndex (ringpop-common/test/node_modules/lodash/index.js:3261:16)
        at Array.validateEventBody [as 8] (ringpop-common/test/ringpop-assert.js:144:23)
        at progressFromCursor (ringpop-common/test/ringpop-assert.js:844:20)
        at TestCoordinator.<anonymous> (ringpop-common/test/ringpop-assert.js:861:9)
        at TestCoordinator.emit (events.js:117:20)
        at TChannelEndpointHandler.handleRequest (ringpop-common/test/fake-node.js:101:30)
        at RequestCallbackHandler.handleRequest (ringpop-common/test/node_modules/tchannel/request-handler.js:62:23)
        at TChannelEndpointHandler.handleRequest (ringpop-common/test/node_modules/tchannel/endpoint-handler.js:71:17)