### PR TITLE
Report test exceptions as failures

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -19,6 +19,7 @@
     "pre-commit": "^0.0.9",
     "tap-parser": "^1.2.2",
     "tape": "^4.2.0",
+    "tape-catch": "^1.0.5",
     "tchannel": "^2.4.6",
     "underscore": "^1.8.3"
   }

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -24,8 +24,9 @@ var TestCoordinator = require('./test-coordinator');
 var getProgramPath = require('./it-tests').getProgramPath;
 var getProgramInterpreter = require('./it-tests').getProgramInterpreter;
 var main = require('./it-tests');
-// test is like normal tape test but also prints t.error.details if a fail occured
-var Test = require('tape');
+// test is like normal tape-catch test but also prints t.error.details if a fail occured.
+// tape-catch catches JS exceptions and reports them as test failures.
+var Test = require('tape-catch');
 
 function test(msg, opts, cb) {
     var t = Test(msg, opts, cb);


### PR DESCRIPTION
We've been hit with this in a [flappy integration test](https://github.com/uber/ringpop-common/pull/66): the test was
throwing a JS exception, but it wasn't visible in the output.

We wrap tape with tape-error to catch these errors.