### PR TITLE
Add controls to tick cluster to stop the gossip in the cluster.

### DIFF
--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -283,10 +283,10 @@ function onData(char) {
             case 'j':
                 joinAll();
                 break;
-            case 'G':
+            case 'g':
                 stopGossip();
                 break;
-            case 'g':
+            case 'G':
                 startGossip();
                 break;
             case 's':
@@ -536,8 +536,8 @@ function main() {
 function displayMenu(logFn) {
     logFn('\td <flag>\tSet debug flag');
     logFn('\tD\t\tClear debug flags');
-    logFn('\tG\t\tStop gossip');
-    logFn('\tg\t\tStart gossip');
+    logFn('\tg\t\tStop gossip');
+    logFn('\tG\t\tStart gossip');
     logFn('\th\t\tHelp menu');
     logFn('\tj\t\tJoin nodes');
     logFn('\tk <count>\tKill processes');

--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -129,7 +129,7 @@ function statsAll() {
                 console.error(color.red('err: ' + err.message + ' [' + host + ']'));
             } else {
                 var membership = JSON.stringify(safeParse(arg3).membership.members);
-                
+
                 var csum = farmhash(membership);
                 if (csums[csum] === undefined) {
                     csums[csum] = [];
@@ -196,11 +196,27 @@ function startGossip() {
     logMsg('cluster', color.cyan('starting gossip on all nodes'));
     hostsUp().forEach(function (host, pos, list) {
         var start = Date.now();
-        send(host, '/admin/gossip', function onSend() {
+        send(host, '/admin/gossip/start', function onSend() {
             var durMs = Date.now() - start;
             completed.push(durMs);
             if (completed.length === list.length) {
                 logMsg('cluster', color.cyan('gossip all completed: ') + color.green(completed.join(', ')));
+            }
+        });
+    });
+}
+
+function stopGossip() {
+    var completed = [];
+
+    logMsg('cluster', color.cyan('stopping gossip on all nodes'));
+    hostsUp().forEach(function (host, pos, list) {
+        var start = Date.now();
+        send(host, '/admin/gossip/stop', function onSend() {
+            var durMs = Date.now() - start;
+            completed.push(durMs);
+            if (completed.length === list.length) {
+                logMsg('cluster', color.cyan('stop gossip all completed: ') + color.green(completed.join(', ')));
             }
         });
     });
@@ -266,6 +282,9 @@ function onData(char) {
                 break;
             case 'j':
                 joinAll();
+                break;
+            case 'G':
+                stopGossip();
                 break;
             case 'g':
                 startGossip();
@@ -517,6 +536,7 @@ function main() {
 function displayMenu(logFn) {
     logFn('\td <flag>\tSet debug flag');
     logFn('\tD\t\tClear debug flags');
+    logFn('\tG\t\tStop gossip');
     logFn('\tg\t\tStart gossip');
     logFn('\th\t\tHelp menu');
     logFn('\tj\t\tJoin nodes');

--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -527,7 +527,7 @@ function main() {
         stdin.resume();
         stdin.setEncoding('utf8');
         stdin.on('data', onData);
-        logMsg('init', color.red('d: debug flags, g: gossip, j: join, k: kill, K: revive all, l: sleep, p: protocol stats, q: quit, s: cluster stats, t: tick'));
+        logMsg('init', color.red('d: debug flags, g: stop gossip, G: start gossip, j: join, k: kill, K: revive all, l: sleep, p: protocol stats, q: quit, s: cluster stats, t: tick'));
     } catch (e) {
         logMsg('init', 'Unable to open stdin; interactive commands disabled');
     }


### PR DESCRIPTION
Tick cluster already had controls to start the gossip of the cluster, with this feature it is now also able to stop the gossiping of the cluster.

This was useful in debugging dissemination behavior step by step in combination with the tick command in tick cluster.