### PR TITLE
Validate ping response after a reincarnation to be correct

### DIFF
--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -52,7 +52,8 @@ var features = {
     'reincarnate': {
         mandatory: true,
         tests: [
-            './incarnation-no-tests'
+            './incarnation-no-tests',
+            './reincarnation-source'
         ]
     },
     'gossip': {

--- a/test/reincarnation-source.js
+++ b/test/reincarnation-source.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var events = require('./events');
+var dsl = require('./ringpop-assert');
+var test2 = require('./test-util').test2;
+var prepareCluster = require('./test-util').prepareCluster;
+var _ = require('lodash');
+var getClusterSizes = require('./it-tests').getClusterSizes;
+
+test2('ringpop gossips its reincarnation with itself as the source', getClusterSizes(2), 20000,
+    prepareCluster(function(t, tc, n) { return [
+        // do not disable node
+        dsl.sendPing(t, tc, 0, {
+            sourceIx: 0,
+            subjectIx: 'sut',
+            status: 'suspect'
+        }),
+        dsl.validateEventBody(t, tc, {
+            type: events.Types.Ping,
+            direction: 'response'
+        }, 'find and validate reincarnation gossip', function (ping) {
+            var reincarnation = _.find(ping.body.changes, {
+               address: tc.sutHostPort
+            });
+            return reincarnation
+                && reincarnation.source == tc.sutHostPort
+                && reincarnation.sourceIncarnationNumber == reincarnation.incarnationNumber
+                && reincarnation.status == 'alive';
+
+        }),
+    ];})
+);

--- a/test/reincarnation-source.js
+++ b/test/reincarnation-source.js
@@ -27,7 +27,7 @@ var getClusterSizes = require('./it-tests').getClusterSizes;
 
 test2('ringpop gossips its reincarnation with itself as the source', getClusterSizes(2), 20000,
     prepareCluster(function(t, tc, n) { return [
-        // do not disable node
+        // send ping that causes the sut to reincarnate
         dsl.sendPing(t, tc, 0, {
             sourceIx: 0,
             subjectIx: 'sut',
@@ -45,5 +45,7 @@ test2('ringpop gossips its reincarnation with itself as the source', getClusterS
                 && reincarnation.sourceIncarnationNumber == reincarnation.incarnationNumber
                 && reincarnation.status == 'alive';
         }),
+        // if this test fails due to join requests being left in the queue the
+        // test triggered a full sync.
     ];})
 );

--- a/test/reincarnation-source.js
+++ b/test/reincarnation-source.js
@@ -44,7 +44,6 @@ test2('ringpop gossips its reincarnation with itself as the source', getClusterS
                 && reincarnation.source == tc.sutHostPort
                 && reincarnation.sourceIncarnationNumber == reincarnation.incarnationNumber
                 && reincarnation.status == 'alive';
-
         }),
     ];})
 );


### PR DESCRIPTION
Ringpop used to gossip a reincarnation as coming from the node that made the initial declaration of a new state which caused the reincarnation to be filtered out to the node that made the initial declaration. Therefor delaying and potentially causing a full sync to happen when it should not have happened.

This test is to explicitly test the ping response of a ping triggering a reincarnation.