### PR TITLE
Remove redundant tests

### DIFF
--- a/test/join-tests.js
+++ b/test/join-tests.js
@@ -63,36 +63,3 @@ test2('join ringpop with fake node', getClusterSizes(), 20000,
         dsl.expectOnlyPings(t, tc),
     ];})
 );
-
-function joinFrom(n, status, incNoDelta, deltaAlive, nSuspect, nFaulty) {
-    test2('join from ' + status + ' with incNoDelta ' + incNoDelta, n, 20000,
-        prepareWithStatus(0, status, function(t, tc, n) {
-            return [
-                dsl.disableNode(t, tc, 0),
-                dsl.enableNode(t, tc, 0, tc.fakeNodes[0].incarnationNumber+incNoDelta),
-                dsl.sendJoin(t, tc, 0),
-                dsl.waitForJoinResponse(t, tc, 0),
-                // We expect the node to not accept the join but not change it's own membership
-                // A node is expected to disseminate its own existence
-                function(list, cb) {
-                    tc.fakeNodes[0].incarnationNumber -= incNoDelta;
-                    cb(list);
-                },
-                dsl.assertStats(t, tc, n + deltaAlive, nSuspect, nFaulty, {0: {status: status}}),
-            ];
-        })
-    );
-}
-
-joinFrom(getClusterSizes(2), 'alive', -1, 1, 0, 0);
-joinFrom(getClusterSizes(2), 'alive',  0, 1, 0, 0);
-joinFrom(getClusterSizes(2), 'alive',  1, 1, 0, 0);
-
-joinFrom(getClusterSizes(2), 'suspect', -1, 0, 1, 0);
-joinFrom(getClusterSizes(2), 'suspect',  0, 0, 1, 0);
-joinFrom(getClusterSizes(2), 'suspect',  1, 0, 1, 0);
-
-joinFrom(getClusterSizes(2), 'faulty', -1, 0, 0, 1);
-joinFrom(getClusterSizes(2), 'faulty',  0, 0, 0, 1);
-joinFrom(getClusterSizes(2), 'faulty',  1, 0, 0, 1);
-


### PR DESCRIPTION
A little bit of history: a while ago, /join handler used to accept the
joining node to the membership. It is not the case anymore, so the tests
below do not really make a lot of sense. Deleting.

They are also flapping! There is a race between disableNode and
enableNode. So let's keep ourselves clean.