### PR TITLE
Fix double reincarnation

### DIFF
--- a/test/double-reincarnation.js
+++ b/test/double-reincarnation.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var dsl = require('./ringpop-assert');
+var getClusterSizes = require('./it-tests').getClusterSizes;
+var prepareCluster = require('./test-util').prepareCluster;
+var test2 = require('./test-util').test2;
+
+test2('ringpop should not bump incarnation number when gossip is older', getClusterSizes(2), 20000,
+    prepareCluster(function(t, tc, n) { return [
+        // do not disable node
+        dsl.sendPing(t, tc, 0, {
+            sourceIx: 0,
+            subjectIx: 'sut',
+            status: 'suspect',
+            subjectIncNoDelta: -1 // send a gossip with an older incarnation number
+        }),
+        dsl.waitForPingResponse(t, tc, 0, 1, true),
+
+        // assert stats relies on the incarnation number not being bumped
+        dsl.assertStats(t, tc, n+1, 0, 0),
+    ];})
+);

--- a/test/double-reincarnation.js
+++ b/test/double-reincarnation.js
@@ -32,7 +32,7 @@ test2('ringpop should not bump incarnation number when gossip is older', getClus
             status: 'suspect',
             subjectIncNoDelta: -1 // send a gossip with an older incarnation number
         }),
-        dsl.waitForPingResponse(t, tc, 0, 1, true),
+        dsl.waitForPingResponse(t, tc, 0, 1),
 
         // assert stats relies on the incarnation number not being bumped
         dsl.assertStats(t, tc, n+1, 0, 0),

--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -68,8 +68,6 @@ var features = {
             './admin-tests'
         ]
     },
-
-    // features implemented in only one language
     'reaping-faulty-nodes': {
         mandatory: true,
         tests: [
@@ -86,6 +84,13 @@ var features = {
         mandatory: true,
         tests: [
             './partition-healing-tests'
+        ]
+    },
+
+    // features implemented in only one language
+    'double-reincarnation': {
+        tests: [
+            './double-reincarnation'
         ]
     }
 };

--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -53,7 +53,8 @@ var features = {
         mandatory: true,
         tests: [
             './incarnation-no-tests',
-            './reincarnation-source'
+            './reincarnation-source',
+            './double-reincarnation'
         ]
     },
     'gossip': {
@@ -84,13 +85,6 @@ var features = {
         mandatory: true,
         tests: [
             './partition-healing-tests'
-        ]
-    },
-
-    // features implemented in only one language
-    'double-reincarnation': {
-        tests: [
-            './double-reincarnation'
         ]
     }
 };

--- a/test/reincarnation-source.js
+++ b/test/reincarnation-source.js
@@ -27,7 +27,7 @@ var getClusterSizes = require('./it-tests').getClusterSizes;
 
 test2('ringpop gossips its reincarnation with itself as the source', getClusterSizes(2), 20000,
     prepareCluster(function(t, tc, n) { return [
-        // send ping that causes the sut to reincarnate
+        // do not disable node
         dsl.sendPing(t, tc, 0, {
             sourceIx: 0,
             subjectIx: 'sut',
@@ -44,8 +44,7 @@ test2('ringpop gossips its reincarnation with itself as the source', getClusterS
                 && reincarnation.source == tc.sutHostPort
                 && reincarnation.sourceIncarnationNumber == reincarnation.incarnationNumber
                 && reincarnation.status == 'alive';
+
         }),
-        // if this test fails due to join requests being left in the queue the
-        // test triggered a full sync.
     ];})
 );

--- a/test/reincarnation-source.js
+++ b/test/reincarnation-source.js
@@ -27,7 +27,7 @@ var getClusterSizes = require('./it-tests').getClusterSizes;
 
 test2('ringpop gossips its reincarnation with itself as the source', getClusterSizes(2), 20000,
     prepareCluster(function(t, tc, n) { return [
-        // do not disable node
+        // send ping that causes the sut to reincarnate
         dsl.sendPing(t, tc, 0, {
             sourceIx: 0,
             subjectIx: 'sut',
@@ -45,5 +45,7 @@ test2('ringpop gossips its reincarnation with itself as the source', getClusterS
                 && reincarnation.sourceIncarnationNumber == reincarnation.incarnationNumber
                 && reincarnation.status == 'alive';
         }),
+        // if this test fails due to join requests being left in the queue the
+        // test triggered a full sync.
     ];})
 );

--- a/test/reincarnation-source.js
+++ b/test/reincarnation-source.js
@@ -44,7 +44,6 @@ test2('ringpop gossips its reincarnation with itself as the source', getClusterS
                 && reincarnation.source == tc.sutHostPort
                 && reincarnation.sourceIncarnationNumber == reincarnation.incarnationNumber
                 && reincarnation.status == 'alive';
-
         }),
     ];})
 );

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -896,7 +896,7 @@ function piggyback(tc, opts) {
 
     if(opts.subjectIx === 'sut') {
         update.address = tc.sutHostPort;
-        update.sourceIncarnationNumber = tc.test_state['sutIncarnationNumber'];
+        update.incarnationNumber = tc.test_state['sutIncarnationNumber'];
     } else if(opts.subjectIx === 'new') {
         // address from test network
         update.address = "192.0.2.0:1234";


### PR DESCRIPTION
This PR adds an integration tests assessing that reincarnation only happens for changes that would actually override the state of the node and don't reincarnate if the change will not result in an overridden state.