### PR TITLE
implementation of stat ingester

### DIFF
--- a/cluster-test/test-orchestrator/analysis_examples_test.go
+++ b/cluster-test/test-orchestrator/analysis_examples_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+)
+
+// Check that a section scanner get's the stats between the time labels t0 and t1
+func ExampleSectionScanner() {
+	s := bufio.NewScanner(strings.NewReader(stats))
+	scanner, _ := NewSectionScanner(s, "t0", "t1")
+
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+
+	// Output:
+	// 2016-06-15T16:11:08.246816444Z|ringpop.172_18_24_220_3000.protocol.frequency:200.833341|ms
+	// 2016-06-15T16:11:08.246954825Z|ringpop.172_18_24_220_3000.protocol.delay:200|ms
+	// 2016-06-15T16:11:08.247013319Z|ringpop.172_18_24_220_3000.changes.disseminate:0|g
+	// 2016-06-15T16:11:08.247032205Z|ringpop.172_18_24_220_3000.ping.send:1|c
+	// 2016-06-15T16:11:08.247344365Z|ringpop.172_18_24_220_3008.ping.recv:1|c
+}
+
+func ExampleCountAnalysis() {
+	s := bufio.NewScanner(strings.NewReader(stats))
+	c1, _ := CountAnalysis(s, "ping.send")
+	s = bufio.NewScanner(strings.NewReader(stats))
+	c2, _ := CountAnalysis(s, "changes.disseminate")
+	fmt.Println(c1, c2)
+
+	// Output:
+	// 2 4
+}
+
+var stats = `
+2016-06-15T16:11:08.198146603Z|ringpop.172_18_24_220_3007.protocol.delay:200|ms
+2016-06-15T16:11:08.198191045Z|ringpop.172_18_24_220_3007.changes.disseminate:0|g
+2016-06-15T16:11:08.198212784Z|ringpop.172_18_24_220_3007.ping.send:1|c
+2016-06-15T16:11:08.198622397Z|ringpop.172_18_24_220_3000.ping.recv:1|c
+2016-06-15T16:11:08.198694026Z|ringpop.172_18_24_220_3000.changes.disseminate:0|g
+2016-06-15T16:11:08.19884693Z|ringpop.172_18_24_220_3007.ping:0.593162|ms
+label:t0|cmd: kill 1
+2016-06-15T16:11:08.246816444Z|ringpop.172_18_24_220_3000.protocol.frequency:200.833341|ms
+2016-06-15T16:11:08.246954825Z|ringpop.172_18_24_220_3000.protocol.delay:200|ms
+2016-06-15T16:11:08.247013319Z|ringpop.172_18_24_220_3000.changes.disseminate:0|g
+2016-06-15T16:11:08.247032205Z|ringpop.172_18_24_220_3000.ping.send:1|c
+2016-06-15T16:11:08.247344365Z|ringpop.172_18_24_220_3008.ping.recv:1|c
+label:t1|cmd: wait-for-stable
+2016-06-15T16:11:08.247388872Z|ringpop.172_18_24_220_3008.changes.disseminate:0|g
+2016-06-15T16:11:08.247506122Z|ringpop.172_18_24_220_3000.ping:0.447996|ms
+2016-06-15T16:11:08.25451275Z|ringpop.172_18_24_220_3003.protocol.frequency:203.362966|ms
+2016-06-15T16:11:08.254576313Z|ringpop.172_18_24_220_3003.protocol.delay:200|ms
+`
+
+func ExampleChecksumAnalysis() {
+	s := bufio.NewScanner(strings.NewReader(csumStats))
+	csums, _ := ChecksumsAnalysis(s)
+	fmt.Println(csums)
+
+	// Output:
+	// 3
+}
+
+var csumStats = `
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3005.checksum:4321|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3002.checksum:1234|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3000.checksum:1000|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3001.checksum:1234|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3003.checksum:1234|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3004.checksum:4321|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3006.checksum:4321|g
+`
+
+func ExampleConvergenceTimeAnalysis() {
+	s := bufio.NewScanner(strings.NewReader(convtimeStats))
+	convtime, _ := ConvergenceTimeAnalysis(s)
+	fmt.Println(convtime)
+
+	// Output:
+	// 8s
+}
+
+// time between the first and last recoreded change is 8 seconds
+var convtimeStats = `
+2016-06-17T11:29:15.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:16.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:17.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:18.0Z|ringpop.172_18_24_192_3000.membership-set.suspect:1|c
+2016-06-17T11:29:19.0Z|ringpop.172_18_24_192_3001.membership-set.suspect:1|c
+2016-06-17T11:29:20.0Z|ringpop.172_18_24_192_3002.membership-set.suspect:1|c
+2016-06-17T11:29:21.0Z|ringpop.172_18_24_192_3002.membership-set.suspect:1|c
+2016-06-17T11:29:21.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:21.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:22.0Z|ringpop.172_18_24_192_3003.membership-set.suspect:1|c
+2016-06-17T11:29:23.0Z|ringpop.172_18_24_192_3003.membership-set.suspect:1|c
+2016-06-17T11:29:24.0Z|ringpop.172_18_24_192_3003.membership-set.suspect:1|c
+2016-06-17T11:29:25.0Z|ringpop.172_18_24_192_3004.membership-set.suspect:1|c
+2016-06-17T11:29:26.0Z|ringpop.172_18_24_192_3005.membership-set.suspect:1|c
+2016-06-17T11:29:27.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:28.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:29.0Z|ringpop.172_18_24_192_3000.noise
+`

--- a/cluster-test/test-orchestrator/section_scanner.go
+++ b/cluster-test/test-orchestrator/section_scanner.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"errors"
+	"strings"
+)
+
+// Scanner is inspired on bufio.Scanner. It provides an interface that is
+// commonly used in the following pattern.
+//
+// ```
+// for s.Scan() {
+//     // do something with s.Text()
+// }
+// if s.Err()!=nil {
+//     panic(s.Err())
+// }
+// ```
+type Scanner interface {
+	Scan() bool
+	Text() string
+	Err() error
+}
+
+// A SectionScanner wraps a Scanner and is a Scanner that only scans between
+// the given Start and End labels.
+type SectionScanner struct {
+	Scanner
+	Start string
+	End   string
+}
+
+const (
+	scriptStartLabel = ".."
+	scriptEndLabel   = ".."
+)
+
+// NewSectionScanner returns a Section scanner given Scanner and a start and
+// end label. The scanner is progressed to the Start label and returns an
+// error if that label isn't present.
+func NewSectionScanner(scanner Scanner, start, end string) (*SectionScanner, error) {
+	s := &SectionScanner{
+		Scanner: scanner,
+		Start:   start,
+		End:     end,
+	}
+
+	if start == scriptStartLabel {
+		return s, nil
+	}
+
+	// find section start
+	for s.Scan() {
+		if strings.HasPrefix(s.Text(), "label:"+s.Start) {
+			return s, nil
+		}
+	}
+
+	return nil, errors.New("section start not found, " + s.Start)
+}
+
+// Scan progresses performs one scan on the wrapped Scanner. Returns whether
+// the End label is reached or the wrapped Scanner is finished.
+func (s *SectionScanner) Scan() bool {
+	if s.Scanner.Scan() == false {
+		return false
+	}
+
+	if s.End == scriptEndLabel {
+		return true
+	}
+
+	if strings.HasPrefix(s.Scanner.Text(), "label:"+s.End) {
+		return false
+	}
+
+	return true
+}

--- a/cluster-test/test-orchestrator/section_scanner.go
+++ b/cluster-test/test-orchestrator/section_scanner.go
@@ -70,7 +70,7 @@ func NewSectionScanner(scanner Scanner, start, end string) (*SectionScanner, err
 	}
 
 	// find section start
-	for s.Scan() {
+	for s.Scanner.Scan() {
 		if strings.HasPrefix(s.Text(), "label:"+s.Start) {
 			return s, nil
 		}

--- a/cluster-test/test-orchestrator/section_scanner.go
+++ b/cluster-test/test-orchestrator/section_scanner.go
@@ -18,6 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// A SectionScanner wraps a scanner and filters out all data before the start-
+// label and after the end-label, keeping only the data between the labels.
+// A label indicates when what command of the script of a scenario is ran. The
+// lines that look like "label:t0|cmd: kill 1"" are inserted into the ringpop
+// stats.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/stat_analysis.go
+++ b/cluster-test/test-orchestrator/stat_analysis.go
@@ -18,6 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// This file contains the static ringpop stats analysis for: convergence time;
+// number of converged checksums; and counting of individual stats.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/stat_analysis.go
+++ b/cluster-test/test-orchestrator/stat_analysis.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	membershipChecksumPath = ".checksum:"
+	changesDisseminatePath = "changes.disseminate:"
+	membershipSetPath      = "membership-set"
+	hostportRegex          = "[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,6}"
+)
+
+// CountAnalysis counts the number of occurences of stat in the scanner.
+func CountAnalysis(s Scanner, stat string) (int, error) {
+	stat += ":"
+	count := 0
+	for s.Scan() {
+		// TODO fetch actual count from stat line (don't just count number of lines)
+		if ok, err := regexp.MatchString(stat, s.Text()); ok && err == nil {
+			count++
+		}
+	}
+	if s.Err() != nil {
+		return 0, errors.Wrap(s.Err(), "count analysis\n")
+	}
+
+	return count, nil
+}
+
+// ChecksumsAnalysis counts the number of unique checksums among nodes after
+// scanning all the stats in the scanner.
+func ChecksumsAnalysis(s Scanner) (int, error) {
+	m := make(map[string]string)
+	for s.Scan() {
+		line := s.Text()
+		ix := strings.Index(line, membershipChecksumPath)
+		if ix == -1 || strings.Contains(line, "ring.checksum") {
+			continue
+		}
+
+		csum := line[ix+len(membershipChecksumPath):]
+		if csum[len(csum)-2:] != "|g" {
+			msg := fmt.Sprintf("membership.checksum is not a gauge. csum=%s", csum)
+			return 0, errors.New(msg)
+		}
+		csum = csum[:len(csum)-2]
+
+		r := regexp.MustCompile(hostportRegex)
+		host := r.FindString(line)
+		if host == "" {
+			msg := fmt.Sprintf("membership.checksum stat \"%s\" does not contain host", line)
+			return 0, errors.New(msg)
+		}
+		m[host] = csum
+	}
+	if s.Err() != nil {
+		return 0, errors.Wrap(s.Err(), "checksums analysis\n")
+	}
+
+	return uniq(m), nil
+}
+
+// uniq returns the number of unique values in a map.
+func uniq(m map[string]string) int {
+	u := make(map[string]struct{})
+	for _, csum := range m {
+		u[csum] = struct{}{}
+	}
+	return len(u)
+}
+
+// ConvergenceTimeAnalysis measures the time it takes from the first changes is
+// applied until the last.
+func ConvergenceTimeAnalysis(s Scanner) (time.Duration, error) {
+	var firstChange string
+	var lastChange string
+	for s.Scan() {
+		if strings.Contains(s.Text(), membershipSetPath) {
+			firstChange = s.Text()
+			lastChange = s.Text()
+			break
+		}
+	}
+	if firstChange == "" {
+		return 0, errors.New("first membership change not found in convergence time analysis")
+	}
+
+	for s.Scan() {
+		if strings.Contains(s.Text(), membershipSetPath) {
+			lastChange = s.Text()
+		}
+	}
+	if s.Err() != nil {
+		return 0, errors.Wrap(s.Err(), "convergence time analysis\n")
+	}
+
+	d, err := timeDiff(firstChange, lastChange)
+	if err != nil {
+		return 0, errors.Wrap(err, "convergence time analaysis\n")
+	}
+
+	// force millisecond precission
+	return d / time.Millisecond * time.Millisecond, nil
+}
+
+// timeDiff returns the duration between two stat lines.
+func timeDiff(stat1, stat2 string) (time.Duration, error) {
+	i1 := strings.Index(stat1, "|")
+	if i1 == -1 {
+		msg := fmt.Sprintf("stat1 \"%s\" doesn't contain a timestamp", stat1)
+		return 0, errors.New(msg)
+	}
+	i2 := strings.Index(stat2, "|")
+	if i2 == -1 {
+		msg := fmt.Sprintf("stat2 \"%s\" doesn't contain a timestamp", stat2)
+		return 0, errors.New(msg)
+	}
+
+	t1, err := time.Parse(time.RFC3339Nano, stat1[:i1])
+	if err != nil {
+		return 0, errors.Wrap(err, "parse timestamp stat1\n")
+	}
+	t2, err := time.Parse(time.RFC3339Nano, stat2[:i2])
+	if err != nil {
+		return 0, errors.Wrap(err, "parse timestamp stat2\n")
+	}
+
+	return t2.Sub(t1), nil
+}

--- a/cluster-test/test-orchestrator/stat_analysis.go
+++ b/cluster-test/test-orchestrator/stat_analysis.go
@@ -60,6 +60,8 @@ func ChecksumsAnalysis(s Scanner) (int, error) {
 	for s.Scan() {
 		line := s.Text()
 		ix := strings.Index(line, membershipChecksumPath)
+
+		// filter out everything that is not a membership checksum
 		if ix == -1 || strings.Contains(line, "ring.checksum") {
 			continue
 		}

--- a/cluster-test/test-orchestrator/stat_ingester.go
+++ b/cluster-test/test-orchestrator/stat_ingester.go
@@ -18,6 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// This file contains is responsible for ingesting the ringpop stats of the
+// entire cluster. The stats are analyzed in real-time to assess cluster
+// stability and the stats are at the same time written to a file for later
+// analysis.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/stat_ingestor.go
+++ b/cluster-test/test-orchestrator/stat_ingestor.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// The StatIngester is a UDP server that accepts ringpop stats with added
+// timestamps. The StatIngester analyzes the stream so that it knows when the
+// cluster reaches a stable state. It also writes the stream into a file for
+// later analysis.
+type StatIngester struct {
+	sync.Mutex
+	emptyNodes  map[string]bool
+	file        *os.File
+	wasUnstable bool
+}
+
+// NewStatIngester creates a new StatIngester
+func NewStatIngester() *StatIngester {
+	return &StatIngester{
+		emptyNodes: make(map[string]bool),
+	}
+}
+
+// WaitForStable blocks and waits until the cluster has reached a stable state.
+// waits for the cluster to first become unstable if it isn't already, and then
+// blocks until the cluster has reached a stable state again.
+func (si *StatIngester) WaitForStable(hosts []string) {
+	// wait for cluster to become unstable
+	for !si.wasUnstable {
+		time.Sleep(200 * time.Millisecond)
+	}
+	// wait for cluster to become stable
+	for !si.IsClusterStable(hosts) {
+		time.Sleep(200 * time.Millisecond)
+	}
+	si.wasUnstable = false
+}
+
+// IsClusterStable indicates, judging from the processed stats, whether the
+// cluster is in a stable state. The input are the hosts that should be
+// alive.
+func (si *StatIngester) IsClusterStable(hosts []string) bool {
+	si.Lock()
+	defer si.Unlock()
+
+	for _, h := range hosts {
+		hs := strings.Replace(h, ".", "_", -1)
+		hs = strings.Replace(hs, ":", "_", -1)
+		if empty, ok := si.emptyNodes[hs]; !ok || !empty {
+			return false
+		}
+	}
+	return true
+}
+
+// InsertLabel writes a label into the stats file.
+func (si *StatIngester) InsertLabel(label, cmd string) {
+	writeln(si.file, []byte(fmt.Sprintf("label:%s|cmd: %s", label, cmd)))
+}
+
+// statsQueue will receive all incomming stats for realtime-analysis.
+var statsQueue = make(chan []byte, 1024)
+
+// Listen starts listening on the specified port and writes the data into the
+// specified file.
+func (si *StatIngester) Listen(file string, port string) error {
+	// open output file
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	si.file = f
+
+	// start listening to stats
+	sAddr, err := net.ResolveUDPAddr("udp", ":"+port)
+	if err != nil {
+		return err
+	}
+
+	sConn, err := net.ListenUDP("udp", sAddr)
+	if err != nil {
+		return err
+	}
+
+	go si.startIngestion()
+
+	// handle stats
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := sConn.Read(buf)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			if n == 0 {
+				return
+			}
+
+			// write to file
+			err = writeln(si.file, buf[0:n])
+			if err != nil {
+				log.Fatalln(err)
+			}
+
+			statsQueue <- []byte(string(buf[0:n]))
+		}
+	}()
+
+	return nil
+}
+
+// startIngestion starts a worker that picks stats from the statQueue for
+// realtime-analysis.
+func (si *StatIngester) startIngestion() {
+	for {
+		str, open := <-statsQueue
+		if !open {
+			break
+		}
+		err := si.handleStat(str)
+		if err != nil {
+			err = errors.Wrap(err, "stat ingestion\n")
+			log.Fatalf(err.Error())
+		}
+	}
+}
+
+// handleStat handles a single stat for realtime-analysis.
+func (si *StatIngester) handleStat(buf []byte) error {
+	si.Lock()
+	defer si.Unlock()
+
+	// check if changes were disseminated
+	changes, ok := getBetween(buf, []byte("changes.disseminate:"), []byte("|"))
+	if !ok {
+		return nil
+	}
+	empty := changes == "0"
+
+	// lookup hostport
+	hostport, ok := getBetween(buf, []byte("ringpop."), []byte("."))
+	if !ok {
+		msg := fmt.Sprintf("no hostport found in stat \"%s\"", string(buf))
+		return errors.New(msg)
+	}
+
+	if !empty {
+		si.wasUnstable = true
+	}
+	si.emptyNodes[hostport] = empty
+
+	return nil
+}
+
+// getBetween get a substring from the input buffer between before and after.
+// The function returns whether this was a success.
+func getBetween(buf, before, after []byte) (string, bool) {
+	start := bytes.Index(buf, before)
+	if start == -1 {
+		return "", false
+	}
+	buf = buf[start+len(before):]
+
+	end := bytes.Index(buf, after)
+	if end == -1 {
+		return "", false
+	}
+
+	return string(buf[:end]), true
+}
+
+// writeln is a helper function that writes one line to the writer.
+func writeln(w io.Writer, bts []byte) error {
+	n, err := w.Write(bts)
+	if err != nil {
+		return err
+	}
+	if n != len(bts) {
+		return errors.New("not all bytes were written")
+	}
+
+	newLine := []byte("\n")
+	n, err = w.Write(newLine)
+	if err != nil {
+		return err
+	}
+	if n != len(newLine) {
+		return errors.New("not all bytes were written")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Part 2 of the cluster-test-orchestrator.

In this PR you find the stat ingester of the orchestrator. The stat ingester does real-time analysis to find out if the ringpop cluster is stable and writes the stats to a file for later analysis.