### PR TITLE
placeholders for command, scenario structs and a calculator utility.

### DIFF
--- a/cluster-test/test-orchestrator/analysis_examples_test.go
+++ b/cluster-test/test-orchestrator/analysis_examples_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+)
+
+// Check that a section scanner get's the stats between the time labels t0 and t1
+func ExampleSectionScanner() {
+	s := bufio.NewScanner(strings.NewReader(stats))
+	scanner, _ := NewSectionScanner(s, "t0", "t1")
+
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+
+	// Output:
+	// 2016-06-15T16:11:08.246816444Z|ringpop.172_18_24_220_3000.protocol.frequency:200.833341|ms
+	// 2016-06-15T16:11:08.246954825Z|ringpop.172_18_24_220_3000.protocol.delay:200|ms
+	// 2016-06-15T16:11:08.247013319Z|ringpop.172_18_24_220_3000.changes.disseminate:0|g
+	// 2016-06-15T16:11:08.247032205Z|ringpop.172_18_24_220_3000.ping.send:1|c
+	// 2016-06-15T16:11:08.247344365Z|ringpop.172_18_24_220_3008.ping.recv:1|c
+}
+
+func ExampleCountAnalysis() {
+	s := bufio.NewScanner(strings.NewReader(stats))
+	c1, _ := CountAnalysis(s, "ping.send")
+	s = bufio.NewScanner(strings.NewReader(stats))
+	c2, _ := CountAnalysis(s, "changes.disseminate")
+	fmt.Println(c1, c2)
+
+	// Output:
+	// 2 4
+}
+
+var stats = `
+2016-06-15T16:11:08.198146603Z|ringpop.172_18_24_220_3007.protocol.delay:200|ms
+2016-06-15T16:11:08.198191045Z|ringpop.172_18_24_220_3007.changes.disseminate:0|g
+2016-06-15T16:11:08.198212784Z|ringpop.172_18_24_220_3007.ping.send:1|c
+2016-06-15T16:11:08.198622397Z|ringpop.172_18_24_220_3000.ping.recv:1|c
+2016-06-15T16:11:08.198694026Z|ringpop.172_18_24_220_3000.changes.disseminate:0|g
+2016-06-15T16:11:08.19884693Z|ringpop.172_18_24_220_3007.ping:0.593162|ms
+label:t0|cmd: kill 1
+2016-06-15T16:11:08.246816444Z|ringpop.172_18_24_220_3000.protocol.frequency:200.833341|ms
+2016-06-15T16:11:08.246954825Z|ringpop.172_18_24_220_3000.protocol.delay:200|ms
+2016-06-15T16:11:08.247013319Z|ringpop.172_18_24_220_3000.changes.disseminate:0|g
+2016-06-15T16:11:08.247032205Z|ringpop.172_18_24_220_3000.ping.send:1|c
+2016-06-15T16:11:08.247344365Z|ringpop.172_18_24_220_3008.ping.recv:1|c
+label:t1|cmd: wait-for-stable
+2016-06-15T16:11:08.247388872Z|ringpop.172_18_24_220_3008.changes.disseminate:0|g
+2016-06-15T16:11:08.247506122Z|ringpop.172_18_24_220_3000.ping:0.447996|ms
+2016-06-15T16:11:08.25451275Z|ringpop.172_18_24_220_3003.protocol.frequency:203.362966|ms
+2016-06-15T16:11:08.254576313Z|ringpop.172_18_24_220_3003.protocol.delay:200|ms
+`
+
+func ExampleChecksumAnalysis() {
+	s := bufio.NewScanner(strings.NewReader(csumStats))
+	csums, _ := ChecksumsAnalysis(s)
+	fmt.Println(csums)
+
+	// Output:
+	// 3
+}
+
+var csumStats = `
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3005.checksum:4321|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3002.checksum:1234|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3000.checksum:1000|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3001.checksum:1234|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3003.checksum:1234|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3004.checksum:4321|g
+2016-06-17T11:29:18.254046798Z|ringpop.172_18_24_192_3006.checksum:4321|g
+`
+
+func ExampleConvergenceTimeAnalysis() {
+	s := bufio.NewScanner(strings.NewReader(convtimeStats))
+	convtime, _ := ConvergenceTimeAnalysis(s)
+	fmt.Println(convtime)
+
+	// Output:
+	// 8s
+}
+
+// time between the first and last recoreded change is 8 seconds
+var convtimeStats = `
+2016-06-17T11:29:15.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:16.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:17.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:18.0Z|ringpop.172_18_24_192_3000.membership-set.suspect:1|c
+2016-06-17T11:29:19.0Z|ringpop.172_18_24_192_3001.membership-set.suspect:1|c
+2016-06-17T11:29:20.0Z|ringpop.172_18_24_192_3002.membership-set.suspect:1|c
+2016-06-17T11:29:21.0Z|ringpop.172_18_24_192_3002.membership-set.suspect:1|c
+2016-06-17T11:29:21.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:21.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:22.0Z|ringpop.172_18_24_192_3003.membership-set.suspect:1|c
+2016-06-17T11:29:23.0Z|ringpop.172_18_24_192_3003.membership-set.suspect:1|c
+2016-06-17T11:29:24.0Z|ringpop.172_18_24_192_3003.membership-set.suspect:1|c
+2016-06-17T11:29:25.0Z|ringpop.172_18_24_192_3004.membership-set.suspect:1|c
+2016-06-17T11:29:26.0Z|ringpop.172_18_24_192_3005.membership-set.suspect:1|c
+2016-06-17T11:29:27.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:28.0Z|ringpop.172_18_24_192_3000.noise
+2016-06-17T11:29:29.0Z|ringpop.172_18_24_192_3000.noise
+`

--- a/cluster-test/test-orchestrator/assertion.go
+++ b/cluster-test/test-orchestrator/assertion.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"reflect"
+	"time"
+)
+
+// An Assertion checks if a Value is equal or is contained by an interval.
+type Assertion struct {
+	Type AssertionType // can be is or in
+
+	// This is the Value of the Assertion in case of AssertionTypeIs
+	// or the first Value of the interval in case of AssertionTypeIn.
+	V1 Value
+
+	// The second Value of the interval in case of AssertionTypeIn.
+	// This value is ignored in case of AssertionTypeIs.
+	V2 Value
+}
+
+// AssertionType is the type (in or is) of an Assertion
+type AssertionType string
+
+const (
+	// AssertionTypeIs is the type that is used for exact comparisons
+	AssertionTypeIs AssertionType = "is"
+
+	// AssertionTypeIn is the type that is used to check a value is containded
+	// by an interval.
+	AssertionTypeIn AssertionType = "in"
+)
+
+// String converts an assertion to its string representation. Some examples:
+//
+// - is 4
+// - in (90, 110)
+// - in (1s, 2s)
+func (a *Assertion) String() string {
+	if a == nil {
+		return ""
+	}
+	if a.Type == AssertionTypeIs {
+		return fmt.Sprintf("is %v", a.V1)
+	}
+	if a.Type == AssertionTypeIn {
+		return fmt.Sprintf("in (%v,%v)", a.V1, a.V2)
+	}
+
+	log.Fatalf("Unknown assertion %s", a.Type)
+	return ""
+}
+
+// Assert makes the assertion. Returns an error if the assertion failed.
+func (a *Assertion) Assert(v Value) error {
+	if a == nil {
+		return nil
+	}
+
+	switch a.Type {
+	case AssertionTypeIs:
+		return equalsAssert(v, a.V1)
+	case AssertionTypeIn:
+		return rangeAssert(v, a.V1, a.V2)
+	}
+
+	msg := fmt.Sprintf("assertion type must be 'in' or 'is' but is %v", a.Type)
+	return errors.New(msg)
+}
+
+// isAssert checks if the Values are equal and returns an error otherwise.
+func equalsAssert(v, V1 Value) error {
+	if reflect.DeepEqual(v, V1) {
+		return nil
+	}
+
+	msg := fmt.Sprintf("assertion expected %v got %v ", V1, v)
+	return errors.New(msg)
+}
+
+// inAssert checks if the Value is contained by the interval (V1, V2) and
+// returns an error otherwise.
+func rangeAssert(v, V1, V2 Value) error {
+	// check if types match
+	tv := reflect.TypeOf(v)
+	tv1 := reflect.TypeOf(V1)
+	tv2 := reflect.TypeOf(V2)
+	if tv != tv1 || tv != tv2 {
+		msg := fmt.Sprintf("assertion type mismatch %v (%v,%v)", v, V1, V2)
+		return errors.New(msg)
+	}
+
+	// convert to float for easy comparison
+	f := toFloat64(v)
+	f1 := toFloat64(V1)
+	f2 := toFloat64(V2)
+
+	if f < f1 || f2 < f {
+		msg := fmt.Sprintf("assertion %v not in (%v,%v)", v, V1, V2)
+		return errors.New(msg)
+	}
+
+	return nil
+}
+
+// toFloat64 converts a value into a float64. Even is the value is a duration
+// because time.Duration is a uint64 which we can convert to a float64.
+func toFloat64(v Value) float64 {
+	if f, ok := v.(float64); ok {
+		return f
+	}
+	return float64(v.(time.Duration))
+}

--- a/cluster-test/test-orchestrator/assertion_test.go
+++ b/cluster-test/test-orchestrator/assertion_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func ExampleAssertion() {
+	a := Assertion{AssertionTypeIn, time.Second, time.Second * 3}
+	fmt.Println(a)
+
+	// Output:
+}

--- a/cluster-test/test-orchestrator/calc.go
+++ b/cluster-test/test-orchestrator/calc.go
@@ -47,7 +47,8 @@ func Eval(expression string) (f float64, err error) {
 	// parse expression
 	expr, err := parser.ParseExpr(expression)
 	if err != nil {
-		return 0, errors.Wrapf(err, "eval %s\n", expression)
+		msg := fmt.Sprintf("eval error for expression: \"%s\"", expression)
+		return 0, errors.New(msg)
 	}
 
 	// evaluate expression

--- a/cluster-test/test-orchestrator/calc.go
+++ b/cluster-test/test-orchestrator/calc.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// Eval evaluates the value of an expression to a float64. It can be used
+// as a simple calculator. e.g: `"2+3*4" -> 14.0`.
+func Eval(expression string) (f float64, err error) {
+	// recover from panic and change the err return value
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(fmt.Sprint(r))
+		}
+	}()
+
+	// parse expression
+	expr, err := parser.ParseExpr(expression)
+	if err != nil {
+		return 0, errors.Wrapf(err, "eval %s\n", expression)
+	}
+
+	// evaluate expression
+	return eval(expr), nil
+}
+
+// eval evaluates an ast.Expr, panicking when there is a problem.
+// This function is called by Eval which recovers from the panics.
+func eval(expr ast.Expr) float64 {
+	switch e := expr.(type) {
+	case *ast.ParenExpr:
+		return eval(e.X)
+
+	case *ast.BinaryExpr:
+		return evalBin(e)
+
+	case *ast.BasicLit:
+		v, err := strconv.ParseFloat(e.Value, 64)
+		if err != nil {
+			panic(fmt.Sprintf("cannot convert BasicLit to float, %v", e))
+		}
+		return v
+	}
+
+	panic(fmt.Sprintf("calculator doesn't handle type %T", expr))
+	return 0
+}
+
+// evalBin executes the binary operator "+", "-", "*" or "/" on two
+func evalBin(expr *ast.BinaryExpr) float64 {
+	x := eval(expr.X)
+	y := eval(expr.Y)
+
+	switch expr.Op.String() {
+	case "*":
+		return x * y
+	case "/":
+		return x / y
+	case "+":
+		return x + y
+	case "-":
+		return x - y
+	}
+
+	panic(fmt.Sprintf("unsupported operator %s", expr.Op))
+	return 0
+}

--- a/cluster-test/test-orchestrator/calc.go
+++ b/cluster-test/test-orchestrator/calc.go
@@ -18,6 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// The file contains a utility for calculation expressions. This is useful when
+// parsing the tests because when for example we want to assert that the
+// number of suspect declarations in a split brane is equal to
+// "N/2 * N/2 * 2" where N is the cluster size.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/calc_test.go
+++ b/cluster-test/test-orchestrator/calc_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+func ExampleEval() {
+	fmt.Println(Eval(""))
+	fmt.Println(Eval("1s"))
+	fmt.Println(Eval("2+(3*4"))
+	fmt.Println(Eval("2+3*4)"))
+	fmt.Println(Eval("(1.5+)*(3+4)"))
+
+	fmt.Println(Eval("123"))
+	fmt.Println(Eval("12.34"))
+	fmt.Println(Eval("2+3*4"))
+	fmt.Println(Eval("2*(3+5)"))
+	fmt.Println(Eval("(1.5*3)*(3+4)"))
+	fmt.Println(Eval("(1.5*(3))*(3+4)"))
+
+	// Output:
+	// 0 eval error for expression: ""
+	// 0 eval error for expression: "1s"
+	// 0 eval error for expression: "2+(3*4"
+	// 0 eval error for expression: "2+3*4)"
+	// 0 eval error for expression: "(1.5+)*(3+4)"
+	// 123 <nil>
+	// 12.34 <nil>
+	// 14 <nil>
+	// 16 <nil>
+	// 31.5 <nil>
+	// 31.5 <nil>
+
+}

--- a/cluster-test/test-orchestrator/command.go
+++ b/cluster-test/test-orchestrator/command.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+var ringpopPort = "3000"
+
+// Command runs command that affect the cluster in different ways. Commands are
+// commenly used to form the Script field of the Scenario struct.
+type Command struct {
+	// Indicates when the command is run.
+	Label string
+
+	// Cmd can be one of:
+	// - `cluster-kill`
+	// - `cluster-start`
+	// - `cluster-rolling-restart`
+	// - `network-drop <SPLIT> <PERCENTAGE>`
+	// - `network-delay <SPLIT> <DURATION>`
+	// - `wait-for-stable`
+	Cmd string
+
+	// The arguments of the command.
+	Args []string
+}
+
+// String converts a Command to a string.
+func (cmd Command) String() string {
+	return fmt.Sprintf("%s %s", cmd.Cmd, strings.Join(cmd.Args, " "))
+}

--- a/cluster-test/test-orchestrator/measurement.go
+++ b/cluster-test/test-orchestrator/measurement.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Value should ever be either a float64 or a time.Duration.
+type Value interface{}
+
+// A Measurement generates a Value which can be either a duration or a number
+// from ringpop stats. The Measurement can count stat occurrences, analyze
+// convergence time, and analyze membership checksum convergence.
+//
+// The Measurement also carries an assertion that determines whether the
+// measured Value is as expected.
+type Measurement struct {
+	// Selects a window of the stats that we want to measure
+	// the values should be equal to one of the Labels in the
+	// Commands of the script.
+	Start, End string
+
+	// One of count, convtime or checksums.
+	Quantity string
+
+	// Currently only count accepts an argument, which is the statpath of
+	// the stats we want to count.
+	Args []string
+
+	// The expected result of this measurement.
+	Assertion *Assertion
+}
+
+// String converts the Measurement into a string.
+func (m *Measurement) String() string {
+	strs := []string{m.Quantity}
+	strs = append(strs, m.Args...)
+	if m.Assertion != nil {
+		strs = append(strs, m.Assertion.String())
+	}
+	return strings.Join(strs, " ")
+}
+
+// Measure performs the measurement and returns the resulting value on stats
+// that are extracted from the given Scanner.
+func (m *Measurement) Measure(s Scanner) (Value, error) {
+	// select stats window we want to to measure on
+	var err error
+	s, err = NewSectionScanner(s, m.Start, m.End)
+	if err != nil {
+		return nil, errors.Wrapf(err, "measure %s\n", m)
+	}
+	switch m.Quantity {
+	case "convtime":
+		convtime, err := ConvergenceTimeAnalysis(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "measure %s\n", m)
+		}
+		return convtime, nil
+	case "checksums":
+		csums, err := ChecksumsAnalysis(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "measure %s\n", m)
+		}
+		return float64(csums), nil
+	case "count":
+		if len(m.Args) != 1 {
+			msg := fmt.Sprintf("count expects one argument, has %v", m.Args)
+			return nil, errors.New(msg)
+		}
+		statpath := m.Args[0]
+		count, err := CountAnalysis(s, statpath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "measure %s\n", m)
+		}
+		return float64(count), nil
+	}
+
+	msg := fmt.Sprintf("no such quantity: %s", m.Quantity)
+	return nil, errors.New(msg)
+}

--- a/cluster-test/test-orchestrator/scenario.go
+++ b/cluster-test/test-orchestrator/scenario.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+// A Scenario is a structure that captures the information of a single
+// cluster-test. It contains a script of commands that exercise different
+// failure conditions on ringpop cluster. After the script has run different
+// measurements on the ringpop stats that the cluster emits are executed.
+// It is possible to add constraints in the form of Assertions to these
+// measurements.
+type Scenario struct {
+	Name string
+	Size int
+	Desc string
+
+	Script  []*Command
+	Measure []*Measurement
+}

--- a/cluster-test/test-orchestrator/section_scanner.go
+++ b/cluster-test/test-orchestrator/section_scanner.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"errors"
+	"strings"
+)
+
+// Scanner is inspired on bufio.Scanner. It provides an interface that is
+// commonly used in the following pattern.
+//
+// ```
+// for s.Scan() {
+//     // do something with s.Text()
+// }
+// if s.Err()!=nil {
+//     panic(s.Err())
+// }
+// ```
+type Scanner interface {
+	Scan() bool
+	Text() string
+	Err() error
+}
+
+// A SectionScanner wraps a Scanner and is a Scanner that only scans between
+// the given Start and End labels.
+type SectionScanner struct {
+	Scanner
+	Start string
+	End   string
+}
+
+const (
+	scriptStartLabel = ".."
+	scriptEndLabel   = ".."
+)
+
+// NewSectionScanner returns a Section scanner given Scanner and a start and
+// end label. The scanner is progressed to the Start label and returns an
+// error if that label isn't present.
+func NewSectionScanner(scanner Scanner, start, end string) (*SectionScanner, error) {
+	s := &SectionScanner{
+		Scanner: scanner,
+		Start:   start,
+		End:     end,
+	}
+
+	if start == scriptStartLabel {
+		return s, nil
+	}
+
+	// find section start
+	for s.Scan() {
+		if strings.HasPrefix(s.Text(), "label:"+s.Start) {
+			return s, nil
+		}
+	}
+
+	return nil, errors.New("section start not found, " + s.Start)
+}
+
+// Scan progresses performs one scan on the wrapped Scanner. Returns whether
+// the End label is reached or the wrapped Scanner is finished.
+func (s *SectionScanner) Scan() bool {
+	if s.Scanner.Scan() == false {
+		return false
+	}
+
+	if s.End == scriptEndLabel {
+		return true
+	}
+
+	if strings.HasPrefix(s.Scanner.Text(), "label:"+s.End) {
+		return false
+	}
+
+	return true
+}

--- a/cluster-test/test-orchestrator/section_scanner.go
+++ b/cluster-test/test-orchestrator/section_scanner.go
@@ -70,7 +70,7 @@ func NewSectionScanner(scanner Scanner, start, end string) (*SectionScanner, err
 	}
 
 	// find section start
-	for s.Scan() {
+	for s.Scanner.Scan() {
 		if strings.HasPrefix(s.Text(), "label:"+s.Start) {
 			return s, nil
 		}

--- a/cluster-test/test-orchestrator/section_scanner.go
+++ b/cluster-test/test-orchestrator/section_scanner.go
@@ -18,6 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// A SectionScanner wraps a scanner and filters out all data before the start-
+// label and after the end-label, keeping only the data between the labels.
+// A label indicates when what command of the script of a scenario is ran. The
+// lines that look like "label:t0|cmd: kill 1"" are inserted into the ringpop
+// stats.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/stat_analysis.go
+++ b/cluster-test/test-orchestrator/stat_analysis.go
@@ -18,6 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// This file contains the static ringpop stats analysis for: convergence time;
+// number of converged checksums; and counting of individual stats.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/stat_analysis.go
+++ b/cluster-test/test-orchestrator/stat_analysis.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	membershipChecksumPath = ".checksum:"
+	changesDisseminatePath = "changes.disseminate:"
+	membershipSetPath      = "membership-set"
+	hostportRegex          = "[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,6}"
+)
+
+// CountAnalysis counts the number of occurences of stat in the scanner.
+func CountAnalysis(s Scanner, stat string) (int, error) {
+	stat += ":"
+	count := 0
+	for s.Scan() {
+		// TODO fetch actual count from stat line (don't just count number of lines)
+		if ok, err := regexp.MatchString(stat, s.Text()); ok && err == nil {
+			count++
+		}
+	}
+	if s.Err() != nil {
+		return 0, errors.Wrap(s.Err(), "count analysis\n")
+	}
+
+	return count, nil
+}
+
+// ChecksumsAnalysis counts the number of unique checksums among nodes after
+// scanning all the stats in the scanner.
+func ChecksumsAnalysis(s Scanner) (int, error) {
+	m := make(map[string]string)
+	for s.Scan() {
+		line := s.Text()
+		ix := strings.Index(line, membershipChecksumPath)
+		if ix == -1 || strings.Contains(line, "ring.checksum") {
+			continue
+		}
+
+		csum := line[ix+len(membershipChecksumPath):]
+		if csum[len(csum)-2:] != "|g" {
+			msg := fmt.Sprintf("membership.checksum is not a gauge. csum=%s", csum)
+			return 0, errors.New(msg)
+		}
+		csum = csum[:len(csum)-2]
+
+		r := regexp.MustCompile(hostportRegex)
+		host := r.FindString(line)
+		if host == "" {
+			msg := fmt.Sprintf("membership.checksum stat \"%s\" does not contain host", line)
+			return 0, errors.New(msg)
+		}
+		m[host] = csum
+	}
+	if s.Err() != nil {
+		return 0, errors.Wrap(s.Err(), "checksums analysis\n")
+	}
+
+	return uniq(m), nil
+}
+
+// uniq returns the number of unique values in a map.
+func uniq(m map[string]string) int {
+	u := make(map[string]struct{})
+	for _, csum := range m {
+		u[csum] = struct{}{}
+	}
+	return len(u)
+}
+
+// ConvergenceTimeAnalysis measures the time it takes from the first changes is
+// applied until the last.
+func ConvergenceTimeAnalysis(s Scanner) (time.Duration, error) {
+	var firstChange string
+	var lastChange string
+	for s.Scan() {
+		if strings.Contains(s.Text(), membershipSetPath) {
+			firstChange = s.Text()
+			lastChange = s.Text()
+			break
+		}
+	}
+	if firstChange == "" {
+		return 0, errors.New("first membership change not found in convergence time analysis")
+	}
+
+	for s.Scan() {
+		if strings.Contains(s.Text(), membershipSetPath) {
+			lastChange = s.Text()
+		}
+	}
+	if s.Err() != nil {
+		return 0, errors.Wrap(s.Err(), "convergence time analysis\n")
+	}
+
+	d, err := timeDiff(firstChange, lastChange)
+	if err != nil {
+		return 0, errors.Wrap(err, "convergence time analaysis\n")
+	}
+
+	// force millisecond precission
+	return d / time.Millisecond * time.Millisecond, nil
+}
+
+// timeDiff returns the duration between two stat lines.
+func timeDiff(stat1, stat2 string) (time.Duration, error) {
+	i1 := strings.Index(stat1, "|")
+	if i1 == -1 {
+		msg := fmt.Sprintf("stat1 \"%s\" doesn't contain a timestamp", stat1)
+		return 0, errors.New(msg)
+	}
+	i2 := strings.Index(stat2, "|")
+	if i2 == -1 {
+		msg := fmt.Sprintf("stat2 \"%s\" doesn't contain a timestamp", stat2)
+		return 0, errors.New(msg)
+	}
+
+	t1, err := time.Parse(time.RFC3339Nano, stat1[:i1])
+	if err != nil {
+		return 0, errors.Wrap(err, "parse timestamp stat1\n")
+	}
+	t2, err := time.Parse(time.RFC3339Nano, stat2[:i2])
+	if err != nil {
+		return 0, errors.Wrap(err, "parse timestamp stat2\n")
+	}
+
+	return t2.Sub(t1), nil
+}

--- a/cluster-test/test-orchestrator/stat_analysis.go
+++ b/cluster-test/test-orchestrator/stat_analysis.go
@@ -60,6 +60,8 @@ func ChecksumsAnalysis(s Scanner) (int, error) {
 	for s.Scan() {
 		line := s.Text()
 		ix := strings.Index(line, membershipChecksumPath)
+
+		// filter out everything that is not a membership checksum
 		if ix == -1 || strings.Contains(line, "ring.checksum") {
 			continue
 		}

--- a/cluster-test/test-orchestrator/stat_ingester.go
+++ b/cluster-test/test-orchestrator/stat_ingester.go
@@ -18,6 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// This file contains is responsible for ingesting the ringpop stats of the
+// entire cluster. The stats are analyzed in real-time to assess cluster
+// stability and the stats are at the same time written to a file for later
+// analysis.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/stat_ingestor.go
+++ b/cluster-test/test-orchestrator/stat_ingestor.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// The StatIngester is a UDP server that accepts ringpop stats with added
+// timestamps. The StatIngester analyzes the stream so that it knows when the
+// cluster reaches a stable state. It also writes the stream into a file for
+// later analysis.
+type StatIngester struct {
+	sync.Mutex
+	emptyNodes  map[string]bool
+	file        *os.File
+	wasUnstable bool
+}
+
+// NewStatIngester creates a new StatIngester
+func NewStatIngester() *StatIngester {
+	return &StatIngester{
+		emptyNodes: make(map[string]bool),
+	}
+}
+
+// WaitForStable blocks and waits until the cluster has reached a stable state.
+// waits for the cluster to first become unstable if it isn't already, and then
+// blocks until the cluster has reached a stable state again.
+func (si *StatIngester) WaitForStable(hosts []string) {
+	// wait for cluster to become unstable
+	for !si.wasUnstable {
+		time.Sleep(200 * time.Millisecond)
+	}
+	// wait for cluster to become stable
+	for !si.IsClusterStable(hosts) {
+		time.Sleep(200 * time.Millisecond)
+	}
+	si.wasUnstable = false
+}
+
+// IsClusterStable indicates, judging from the processed stats, whether the
+// cluster is in a stable state. The input are the hosts that should be
+// alive.
+func (si *StatIngester) IsClusterStable(hosts []string) bool {
+	si.Lock()
+	defer si.Unlock()
+
+	for _, h := range hosts {
+		hs := strings.Replace(h, ".", "_", -1)
+		hs = strings.Replace(hs, ":", "_", -1)
+		if empty, ok := si.emptyNodes[hs]; !ok || !empty {
+			return false
+		}
+	}
+	return true
+}
+
+// InsertLabel writes a label into the stats file.
+func (si *StatIngester) InsertLabel(label, cmd string) {
+	writeln(si.file, []byte(fmt.Sprintf("label:%s|cmd: %s", label, cmd)))
+}
+
+// statsQueue will receive all incomming stats for realtime-analysis.
+var statsQueue = make(chan []byte, 1024)
+
+// Listen starts listening on the specified port and writes the data into the
+// specified file.
+func (si *StatIngester) Listen(file string, port string) error {
+	// open output file
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	si.file = f
+
+	// start listening to stats
+	sAddr, err := net.ResolveUDPAddr("udp", ":"+port)
+	if err != nil {
+		return err
+	}
+
+	sConn, err := net.ListenUDP("udp", sAddr)
+	if err != nil {
+		return err
+	}
+
+	go si.startIngestion()
+
+	// handle stats
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := sConn.Read(buf)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			if n == 0 {
+				return
+			}
+
+			// write to file
+			err = writeln(si.file, buf[0:n])
+			if err != nil {
+				log.Fatalln(err)
+			}
+
+			statsQueue <- []byte(string(buf[0:n]))
+		}
+	}()
+
+	return nil
+}
+
+// startIngestion starts a worker that picks stats from the statQueue for
+// realtime-analysis.
+func (si *StatIngester) startIngestion() {
+	for {
+		str, open := <-statsQueue
+		if !open {
+			break
+		}
+		err := si.handleStat(str)
+		if err != nil {
+			err = errors.Wrap(err, "stat ingestion\n")
+			log.Fatalf(err.Error())
+		}
+	}
+}
+
+// handleStat handles a single stat for realtime-analysis.
+func (si *StatIngester) handleStat(buf []byte) error {
+	si.Lock()
+	defer si.Unlock()
+
+	// check if changes were disseminated
+	changes, ok := getBetween(buf, []byte("changes.disseminate:"), []byte("|"))
+	if !ok {
+		return nil
+	}
+	empty := changes == "0"
+
+	// lookup hostport
+	hostport, ok := getBetween(buf, []byte("ringpop."), []byte("."))
+	if !ok {
+		msg := fmt.Sprintf("no hostport found in stat \"%s\"", string(buf))
+		return errors.New(msg)
+	}
+
+	if !empty {
+		si.wasUnstable = true
+	}
+	si.emptyNodes[hostport] = empty
+
+	return nil
+}
+
+// getBetween get a substring from the input buffer between before and after.
+// The function returns whether this was a success.
+func getBetween(buf, before, after []byte) (string, bool) {
+	start := bytes.Index(buf, before)
+	if start == -1 {
+		return "", false
+	}
+	buf = buf[start+len(before):]
+
+	end := bytes.Index(buf, after)
+	if end == -1 {
+		return "", false
+	}
+
+	return string(buf[:end]), true
+}
+
+// writeln is a helper function that writes one line to the writer.
+func writeln(w io.Writer, bts []byte) error {
+	n, err := w.Write(bts)
+	if err != nil {
+		return err
+	}
+	if n != len(bts) {
+		return errors.New("not all bytes were written")
+	}
+
+	newLine := []byte("\n")
+	n, err = w.Write(newLine)
+	if err != nil {
+		return err
+	}
+	if n != len(newLine) {
+		return errors.New("not all bytes were written")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Part 4 of the cluster-test-orchestrator

This PR contains placeholder structs for Command and Scenario which can be filled in by the parser which will be added to Part 5 of the cluster-test-orchestrater in #77.

This PR also contains a calculator utility that is also used while parsing the test yaml-files.
