### PR TITLE
Ws structs for parsing

### DIFF
--- a/cluster-test/test-orchestrator/calc.go
+++ b/cluster-test/test-orchestrator/calc.go
@@ -47,7 +47,8 @@ func Eval(expression string) (f float64, err error) {
 	// parse expression
 	expr, err := parser.ParseExpr(expression)
 	if err != nil {
-		return 0, errors.Wrapf(err, "eval %s\n", expression)
+		msg := fmt.Sprintf("eval error for expression: \"%s\"", expression)
+		return 0, errors.New(msg)
 	}
 
 	// evaluate expression

--- a/cluster-test/test-orchestrator/calc.go
+++ b/cluster-test/test-orchestrator/calc.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// Eval evaluates the value of an expression to a float64. It can be used
+// as a simple calculator. e.g: `"2+3*4" -> 14.0`.
+func Eval(expression string) (f float64, err error) {
+	// recover from panic and change the err return value
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(fmt.Sprint(r))
+		}
+	}()
+
+	// parse expression
+	expr, err := parser.ParseExpr(expression)
+	if err != nil {
+		return 0, errors.Wrapf(err, "eval %s\n", expression)
+	}
+
+	// evaluate expression
+	return eval(expr), nil
+}
+
+// eval evaluates an ast.Expr, panicking when there is a problem.
+// This function is called by Eval which recovers from the panics.
+func eval(expr ast.Expr) float64 {
+	switch e := expr.(type) {
+	case *ast.ParenExpr:
+		return eval(e.X)
+
+	case *ast.BinaryExpr:
+		return evalBin(e)
+
+	case *ast.BasicLit:
+		v, err := strconv.ParseFloat(e.Value, 64)
+		if err != nil {
+			panic(fmt.Sprintf("cannot convert BasicLit to float, %v", e))
+		}
+		return v
+	}
+
+	panic(fmt.Sprintf("calculator doesn't handle type %T", expr))
+	return 0
+}
+
+// evalBin executes the binary operator "+", "-", "*" or "/" on two
+func evalBin(expr *ast.BinaryExpr) float64 {
+	x := eval(expr.X)
+	y := eval(expr.Y)
+
+	switch expr.Op.String() {
+	case "*":
+		return x * y
+	case "/":
+		return x / y
+	case "+":
+		return x + y
+	case "-":
+		return x - y
+	}
+
+	panic(fmt.Sprintf("unsupported operator %s", expr.Op))
+	return 0
+}

--- a/cluster-test/test-orchestrator/calc.go
+++ b/cluster-test/test-orchestrator/calc.go
@@ -18,6 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// The file contains a utility for calculation expressions. This is useful when
+// parsing the tests because when for example we want to assert that the
+// number of suspect declarations in a split brane is equal to
+// "N/2 * N/2 * 2" where N is the cluster size.
+
 package main
 
 import (

--- a/cluster-test/test-orchestrator/calc_test.go
+++ b/cluster-test/test-orchestrator/calc_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+func ExampleEval() {
+	fmt.Println(Eval(""))
+	fmt.Println(Eval("1s"))
+	fmt.Println(Eval("2+(3*4"))
+	fmt.Println(Eval("2+3*4)"))
+	fmt.Println(Eval("(1.5+)*(3+4)"))
+
+	fmt.Println(Eval("123"))
+	fmt.Println(Eval("12.34"))
+	fmt.Println(Eval("2+3*4"))
+	fmt.Println(Eval("2*(3+5)"))
+	fmt.Println(Eval("(1.5*3)*(3+4)"))
+	fmt.Println(Eval("(1.5*(3))*(3+4)"))
+
+	// Output:
+	// 0 eval error for expression: ""
+	// 0 eval error for expression: "1s"
+	// 0 eval error for expression: "2+(3*4"
+	// 0 eval error for expression: "2+3*4)"
+	// 0 eval error for expression: "(1.5+)*(3+4)"
+	// 123 <nil>
+	// 12.34 <nil>
+	// 14 <nil>
+	// 16 <nil>
+	// 31.5 <nil>
+	// 31.5 <nil>
+
+}

--- a/cluster-test/test-orchestrator/command.go
+++ b/cluster-test/test-orchestrator/command.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+var ringpopPort = "3000"
+
+// Command runs command that affect the cluster in different ways. Commands are
+// commenly used to form the Script field of the Scenario struct.
+type Command struct {
+	// Indicates when the command is run.
+	Label string
+
+	// Cmd can be one of:
+	// - `cluster-kill`
+	// - `cluster-start`
+	// - `cluster-rolling-restart`
+	// - `network-drop <SPLIT> <PERCENTAGE>`
+	// - `network-delay <SPLIT> <DURATION>`
+	// - `wait-for-stable`
+	Cmd string
+
+	// The arguments of the command.
+	Args []string
+}
+
+// String converts a Command to a string.
+func (cmd Command) String() string {
+	return fmt.Sprintf("%s %s", cmd.Cmd, strings.Join(cmd.Args, " "))
+}

--- a/cluster-test/test-orchestrator/scenario.go
+++ b/cluster-test/test-orchestrator/scenario.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+// A Scenario is a structure that captures the information of a single
+// cluster-test. It contains a script of commands that exercise different
+// failure conditions on ringpop cluster. After the script has run different
+// measurements on the ringpop stats that the cluster emits are executed.
+// It is possible to add constraints in the form of Assertions to these
+// measurements.
+type Scenario struct {
+	Name string
+	Size int
+	Desc string
+
+	Script  []*Command
+	Measure []*Measurement
+}

--- a/cluster-test/test-orchestrator/test_yaml_parser.go
+++ b/cluster-test/test-orchestrator/test_yaml_parser.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"gopkg.in/yaml.v2"
+)
+
+// testYaml is used to unmarshal test declared in the yaml files.
+type testYaml struct {
+	Config    configYaml
+	Scenarios []*scenarioYaml
+}
+
+type configYaml struct {
+	// TODO(wieger): define
+}
+
+// scenarioYaml captures the information of a scenario.
+type scenarioYaml struct {
+	Name string
+	Size string
+	Desc string
+
+	Script  []map[string]string
+	Measure []string
+	Runs    [][]string
+}
+
+func parse(bts []byte) (scns []*Scenario, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			scns = nil
+			err = errors.New(fmt.Sprint(r))
+		}
+	}()
+
+	return parseScenarios(bts), nil
+}
+
+func parseScenarios(bts []byte) []*Scenario {
+	testYaml := &testYaml{}
+	err := yaml.Unmarshal([]byte(bts), testYaml)
+	if err != nil {
+		panic("failed to unmarshal scenario yaml")
+	}
+
+	return extractScenarios(testYaml)
+}
+
+// extractScenarios returns a scenario for every element in the runs list.
+func extractScenarios(runs *testYaml) []*Scenario {
+	var result []*Scenario
+	for _, scenarioData := range runs.Scenarios {
+		for _, vari := range scenarioData.Runs[0] {
+			if vari[0] != '<' || vari[len(vari)-1] != '>' {
+				panic(fmt.Sprintf("variable '%s' not of the form <var>", vari))
+			}
+		}
+		// We start at i=1 because the first entry of the runs declares the
+		// variables names. e.g. [<N>, <A>, <B>].
+		for i := 1; i < len(scenarioData.Runs); i++ {
+			s := extractScenario(scenarioData, i)
+			result = append(result, s)
+		}
+	}
+
+	return result
+}
+
+// extractScenario returns a scenario given the index of a specific run.
+func extractScenario(data *scenarioYaml, runIx int) *Scenario {
+	varsData := data.Runs[0]
+	runData := data.Runs[runIx]
+	defer wrapPanicf("Failed to parse scenario '%s'", data.Name)
+	defer wrapPanicf("in run %d, [%v] = [%v]", runIx, strings.Join(varsData, ", "), strings.Join(runData, ", "))
+
+	if len(varsData) != len(runData) {
+		msg := fmt.Sprintf("var count of run %v should match var count of %v", runData, varsData)
+		panic(msg)
+	}
+
+	// don't find and replace on name
+	name := data.Name
+	desc := replace(data.Desc, varsData, runData)
+	sizeStr := replace(data.Size, varsData, runData)
+
+	// extract size
+	size, err := strconv.Atoi(sizeStr)
+	if err != nil {
+		panic("size convert: " + err.Error())
+	}
+
+	// extract script
+	labels, cmds := extractScript(data.Script, varsData, runData)
+	script := parseScript(labels, cmds)
+
+	// extract Measure
+	measureStrs := make([]string, len(data.Measure))
+	for i := range data.Measure {
+		measureStrs[i] = replace(data.Measure[i], varsData, runData)
+	}
+	measure := parseMeasurements(measureStrs)
+
+	return &Scenario{
+		Name:    name,
+		Desc:    desc,
+		Size:    size,
+		Script:  script,
+		Measure: measure,
+	}
+}
+
+func extractScript(script []map[string]string, varsData, runData []string) (labels, cmds []string) {
+	labels = make([]string, 0, len(script))
+	cmds = make([]string, 0, len(script))
+	for _, cmdData := range script {
+		if len(cmdData) != 1 {
+			// We are asserting that commands are one line only to comply with
+			// the yaml that looks like:
+			//
+			// script:
+			// - t0: command1
+			// - t1: command2
+			panic(fmt.Sprintf("command '%v' should contain exactly one entry", cmdData))
+		}
+
+		for label, cmd := range cmdData {
+			labels = append(labels, replace(label, varsData, runData))
+			cmds = append(cmds, replace(cmd, varsData, runData))
+		}
+	}
+	return labels, cmds
+}
+
+func parseScript(labels, cmdStrs []string) []*Command {
+	defer wrapPanicf("in parse script")
+	var cmds []*Command
+	for i := range labels {
+		cmd := parseCommand(labels[i], cmdStrs[i])
+		cmds = append(cmds, cmd)
+	}
+
+	return cmds
+}
+
+func parseCommand(label, cmdString string) *Command {
+	defer wrapPanicf("in parse command '%s: %s'", label, cmdString)
+	fields := strings.Fields(cmdString)
+	if len(fields) == 0 {
+		panic("empty command")
+	}
+
+	return &Command{
+		Label: label,
+		Cmd:   fields[0],
+		Args:  fields[1:],
+	}
+}
+
+func parseMeasurements(msData []string) []*Measurement {
+	var ms []*Measurement
+	for _, mData := range msData {
+		ms = append(ms, parseMeasurement(mData))
+	}
+	return ms
+}
+
+func parseMeasurement(str string) *Measurement {
+	defer wrapPanicf("in parse measure '%s'", str)
+
+	fields := strings.Fields(str)
+	if len(fields) < 3 {
+		panic("contains too few fields")
+	}
+
+	measurementArgs := fields[3:]
+
+	// search for optional assertion
+	var assertion *Assertion
+	for i, s := range measurementArgs {
+		if s == "is" || s == "in" {
+			interval := strings.Join(measurementArgs[i+1:], "")
+			assertion = parseAssertion(s, interval)
+			measurementArgs = measurementArgs[:i]
+		}
+	}
+
+	return &Measurement{
+		Start:     fields[0],
+		End:       fields[1],
+		Quantity:  fields[2],
+		Args:      measurementArgs,
+		Assertion: assertion,
+	}
+}
+
+func parseAssertion(typeStr string, arg string) *Assertion {
+	defer wrapPanicf("in parse assertion '%s %s'", typeStr, arg)
+
+	switch typeStr {
+	case "is":
+		typ := AssertionTypeIs
+		v := parseValue(arg)
+		return &Assertion{
+			Type: typ,
+			V1:   v,
+		}
+
+	case "in":
+		typ := AssertionTypeIn
+		v1, v2 := parseRange(arg)
+		return &Assertion{
+			Type: typ,
+			V1:   v1,
+			V2:   v2,
+		}
+	}
+
+	panic("not valid assertion type")
+}
+
+func parseRange(rng string) (v1, v2 Value) {
+	defer wrapPanicf("in parse range '%s'", rng)
+
+	if rng[0] != '(' || rng[len(rng)-1] != ')' {
+		panic("should be enclosed by parenthesis")
+	}
+	split := strings.Split(rng[1:len(rng)-1], ",")
+	if len(split) != 2 {
+		panic("should be split by a comma")
+	}
+
+	v1 = parseValue(split[0])
+	v2 = parseValue(split[1])
+
+	if reflect.TypeOf(v1) != reflect.TypeOf(v2) {
+		panic(fmt.Sprintf("types %T %T should be equal", v1, v2))
+	}
+
+	return v1, v2
+}
+
+func parseValue(str string) Value {
+	defer wrapPanicf("in parse value '%s", str)
+
+	// First check if the input is a number or expression.
+	v, err := Eval(str)
+	if err == nil {
+		return v
+	}
+
+	// Then check if the input is a duration. Duration check needs
+	// to be after Eval to prevent "0" to parse as a duration.
+	d, err := time.ParseDuration(str)
+	if err == nil {
+		return Value(d)
+	}
+
+	panic("value is not a number duration or expression")
+}
+
+// replace finds occurrences of varsData and replaces them by the respective
+// element in the runsData.
+func replace(str string, varsData []string, runData []string) string {
+	for i := range varsData {
+		str = strings.Replace(str, varsData[i], runData[i], -1)
+	}
+	return str
+}
+
+// wrapPanicf recovers from a panic and then starts to panic with a message
+// that adds to the message of the previous panic. This function should always
+// be defered because of the recover and is commonly at the start of a
+// function.
+func wrapPanicf(format string, args ...interface{}) {
+	if r := recover(); r != nil {
+		msg := fmt.Sprintf(format, args...)
+		panic(fmt.Sprintf("%s:\n- %v", msg, r))
+	}
+}


### PR DESCRIPTION
Part 4 of the cluster-test-orchestrator

This PR contains placeholder structs for Command and Scenario which can be filled in by the parser which will be added to Part 5 of the cluster-test-orchestrater in #81 .

This PR also contains a calculator utility that is also used while parsing the test yaml-files.
