### PR TITLE
bump tchannel in integration tests

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -20,7 +20,7 @@
     "tap-parser": "^1.2.2",
     "tape": "^4.2.0",
     "tape-catch": "^1.0.5",
-    "tchannel": "^2.4.6",
+    "tchannel": "^3.6.13",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Current tchannel is outdated. By bumping it, the tests become compatible with node v4. (due to updated sse4_crc32.)
