### PR TITLE
Sigterm from tick-cluster

### DIFF
--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -559,7 +559,7 @@ function displayMenu(logFn) {
     logFn('\th\t\tHelp menu');
     logFn('\tj\t\tJoin nodes');
     logFn('\tk <count>\tKill processes');
-    logFn('\tm <count>\Terminae processes');
+    logFn('\tm <count>\tTerminate processes');
     logFn('\tK\t\tRevive suspended or killed processes');
     logFn('\tl <count>\tSuspend processes');
     logFn('\tp\t\tPrint out protocol stats');

--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -505,9 +505,17 @@ function terminateProc(count) {
         .value();
 
     _.each(processesToKill, function kill(proc) {
-        logMsg(proc.port, color.green('pid ' + proc.pid) + color.red(' randomly selected for termination'));
-        process.kill(proc.proc.pid, 'SIGTERM');
-        proc.killed = Date.now();
+        logMsg(proc.port, color.green('pid ' + proc.pid) + color.red(' randomly selected for termination'));        
+        var hardKillTimer = setTimeout(function(){
+            logMsg(proc.port, color.green('pid ' + proc.pid) + color.red(' didn\'t terminate in 5 seconds. Hard killing...'));
+            proc.proc.kill('SIGKILL');                        
+        }, 5000);
+        proc.proc.once('exit', function(){            
+            clearTimeout(hardKillTimer);
+            logMsg(proc.port, color.green('pid ' + proc.pid) + color.green(' terminated.'));
+            proc.killed = Date.now();
+        });    
+        proc.proc.kill('SIGTERM');            
     });
 }
 

--- a/tools/tick-cluster.js
+++ b/tools/tick-cluster.js
@@ -567,9 +567,9 @@ function displayMenu(logFn) {
     logFn('\th\t\tHelp menu');
     logFn('\tj\t\tJoin nodes');
     logFn('\tk <count>\tKill processes');
-    logFn('\tm <count>\tTerminate processes');
     logFn('\tK\t\tRevive suspended or killed processes');
     logFn('\tl <count>\tSuspend processes');
+    logFn('\tm <count>\tTerminate processes');
     logFn('\tp\t\tPrint out protocol stats');
     logFn('\tq\t\tQuit');
     logFn('\ts\t\tPrint out stats');


### PR DESCRIPTION
To assist in testing self eviction add sending `SIGTERM` to kill running processes.
Note: dependent on `SIGTERM` handling in testpop (see uber/ringpop-node#301)