### PR TITLE
Add integration test for self-eviction

### DIFF
--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -86,6 +86,12 @@ var features = {
         tests: [
             './partition-healing-tests'
         ]
+    },
+    'self-eviction': {
+        mandatory: false,
+        tests: [
+            './self-eviction-tests'
+        ]
     }
 };
 

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -705,6 +705,21 @@ function enableNode(t, tc, ix, incarnationNumber) {
     return f;
 }
 
+function stopGossip(t, tc) {
+    return [
+        callEndpoint(t, tc, '/admin/gossip/stop'),
+        validateEventBody(t, tc, {
+            type: events.Types.AdminGossipStop,
+            direction: 'response'
+        }, "Wait for AdminGossipStop response", function(response) {
+            return true;
+        }),
+        wait(10), // racecondition if a ping was inbound during stopping
+
+        consumePings(t, tc)
+    ]
+}
+
 function createValidateEvent(t, tc) {
     var Validator = jsonschema.Validator;
     var validator = new Validator();
@@ -916,6 +931,17 @@ function piggyback(tc, opts) {
     return update;
 }
 
+function waitForGracefulShutdown(t, tc) {
+    return function gracefulShutdown(list, cb) {
+        tc.sutProc.on('exit', function onExit(code, signal) {
+            t.equal(code, 0, 'exit code is 0');
+            t.equal(signal, null, 'process exited itself');
+            cb(list);
+        });
+
+        tc.sutProc.kill('SIGTERM');
+    }
+}
 
 module.exports = {
     validate: validate,
@@ -951,6 +977,8 @@ module.exports = {
     disableAllNodes: disableAllNodes,
     disableAllNodesPing: disableAllNodesPing,
     enableNode: enableNode,
+    stopGossip: stopGossip,
+    waitForGracefulShutdown: waitForGracefulShutdown,
 
     changeStatus: changeStatus,
     sendPings: sendPings,

--- a/test/self-eviction-tests.js
+++ b/test/self-eviction-tests.js
@@ -60,8 +60,12 @@ function assertValidPings(t, tc, n) {
             type: events.Types.Ping,
             direction: 'request'
         });
+
         if (pings.length === 0) {
-            return cb(null);
+            // We should have at least one ping here,
+            // otherwise self-eviction is not working.
+            t.fail('no pings received');
+            return cb(pings);
         }
 
         var maxPings = Math.ceil(n * 0.4);

--- a/test/self-eviction-tests.js
+++ b/test/self-eviction-tests.js
@@ -51,6 +51,7 @@ test2('self eviction changes state to faulty and pings members', getClusterSizes
  *
  * @param t the current test suite
  * @param tc the test coordinated
+ * @param n the number of servers in the cluster
  * @return {assertValidPings} the assert functions
  */
 function assertValidPings(t, tc, n) {

--- a/test/self-eviction-tests.js
+++ b/test/self-eviction-tests.js
@@ -1,0 +1,82 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var _ = require('lodash');
+var dsl = require('./ringpop-assert');
+var events = require('./events');
+var getClusterSizes = require('./it-tests').getClusterSizes;
+var prepareCluster = require('./test-util').prepareCluster;
+var test2 = require('./test-util').test2;
+
+
+test2('self eviction changes state to faulty and pings members', getClusterSizes(2), 2000000, prepareCluster(function(t, tc, n) {
+    return [
+        // disable pinging from fake nodes
+        dsl.disableAllNodesPing(t, tc),
+
+        // stop gossiping on SUT
+        dsl.stopGossip(t, tc),
+
+        // graceful shutdown SUT (sent SIGTERM and wait till exit)
+        dsl.waitForGracefulShutdown(t, tc),
+
+        // assert pings
+        assertValidPings(t, tc, n)
+    ];
+}));
+
+/**
+ * Validate the pings. Assert that:
+ * - the number of pings doesn't exceed 40% of the cluster
+ * - the pings are all to different members
+ * - the pings should declare the SUT faulty and originate from the SUT itself
+ *
+ * @param t the current test suite
+ * @param tc the test coordinated
+ * @return {assertValidPings} the assert functions
+ */
+function assertValidPings(t, tc, n) {
+    return function assertValidPings(list, cb) {
+        var pings = _.filter(list, {
+            type: events.Types.Ping,
+            direction: 'request'
+        });
+        if (pings.length === 0) {
+            return cb(list);
+        }
+
+        var maxPings = Math.ceil(n * 0.4);
+        t.ok(pings.length <= maxPings, 'number of pings does not exceed 40% of cluster');
+
+        var receivers = _.pluck(pings, 'receiver');
+        t.ok(_.uniq(receivers).length === receivers.length, 'all pings are to unique members');
+
+        _.each(pings, function validatePing(ping) {
+            t.equal(ping.body.changes.length, 1);
+
+            var change = ping.body.changes[0];
+            t.equal(change.source, tc.sutHostPort);
+            t.equal(change.status, 'faulty');
+            t.equal(ping.body.source, tc.sutHostPort);
+        });
+
+        cb(_.reject(list, pings));
+    }
+}

--- a/test/self-eviction-tests.js
+++ b/test/self-eviction-tests.js
@@ -28,10 +28,11 @@ var test2 = require('./test-util').test2;
 
 test2('self eviction changes state to faulty and pings members', getClusterSizes(2), 2000000, prepareCluster(function(t, tc, n) {
     return [
-        // disable pinging from fake nodes
-        dsl.disableAllNodesPing(t, tc),
 
-        // stop gossiping on SUT
+        // disable pinging from fake nodes and stop gossip on the SUT
+        // this is necessary to make sure all the pings assert later on
+        // are sent from the graceful shutdown.
+        dsl.disableAllNodesPing(t, tc),
         dsl.stopGossip(t, tc),
 
         // graceful shutdown SUT (sent SIGTERM and wait till exit)
@@ -59,7 +60,7 @@ function assertValidPings(t, tc, n) {
             direction: 'request'
         });
         if (pings.length === 0) {
-            return cb(list);
+            return cb(null);
         }
 
         var maxPings = Math.ceil(n * 0.4);

--- a/test/self-eviction-tests.js
+++ b/test/self-eviction-tests.js
@@ -26,7 +26,7 @@ var prepareCluster = require('./test-util').prepareCluster;
 var test2 = require('./test-util').test2;
 
 
-test2('self eviction changes state to faulty and pings members', getClusterSizes(2), 2000000, prepareCluster(function(t, tc, n) {
+test2('self eviction changes state to faulty and pings members', getClusterSizes(2), 20000, prepareCluster(function(t, tc, n) {
     return [
 
         // disable pinging from fake nodes and stop gossip on the SUT

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -303,7 +303,7 @@ TestCoordinator.prototype.shutdown = function shutdown() {
     if(this.adminChannel.topChannel.destroyed === false) {
         this.adminChannel.topChannel.close();
     }
-    this.sutProc.kill();
+    this.sutProc.kill('SIGKILL');
     this.fakeNodes.forEach(function shutdownNode(node) {
         node.shutdown();
     });


### PR DESCRIPTION
This test validates self-eviction by:
- stop gossiping in the whole cluster
- send a `SIGTERM ` to SUT
- validate if the SUT declares itself as faulty by pinging other members with the change