### PR TITLE
Add integration tests for ringpop-labels

### DIFF
--- a/schema/admin-stats-response.json
+++ b/schema/admin-stats-response.json
@@ -28,6 +28,14 @@
                             },
                             "dampScore": {
                                 "type": "number"
+                            },
+                            "labels": {
+                                "type": "object",
+                                 "patternProperties": {
+                                    "^.*$": {
+                                        "type": "string"
+                                    }
+                                }
                             }
                         },
                         "required": [

--- a/schema/admin-stats-response.json
+++ b/schema/admin-stats-response.json
@@ -30,12 +30,7 @@
                                 "type": "number"
                             },
                             "labels": {
-                                "type": "object",
-                                 "patternProperties": {
-                                    "^.*$": {
-                                        "type": "string"
-                                    }
-                                }
+                                "$ref": "/Labels"
                             }
                         },
                         "required": [

--- a/schema/change.json
+++ b/schema/change.json
@@ -28,12 +28,7 @@
             "type": "boolean"
         },
         "labels": {
-            "type": "object",
-            "patternProperties": {
-                "^.*$": {
-                    "type": "string"
-                }
-            }
+            "$ref": "/Labels"
         }
     },
     "required": [

--- a/schema/change.json
+++ b/schema/change.json
@@ -26,6 +26,14 @@
         },
         "tombstone": {
             "type": "boolean"
+        },
+        "labels": {
+            "type": "object",
+            "patternProperties": {
+                "^.*$": {
+                    "type": "string"
+                }
+            }
         }
     },
     "required": [

--- a/schema/labels.json
+++ b/schema/labels.json
@@ -1,0 +1,10 @@
+{
+    "id": "/Labels",
+    "title": "Labels",
+    "type": "object",
+    "patternProperties": {
+        "^.*$": {
+            "type": "string"
+        }
+    }
+}

--- a/test/fake-node.js
+++ b/test/fake-node.js
@@ -111,12 +111,22 @@ FakeNode.prototype.shutdown = function shutdown() {
 };
 
 FakeNode.prototype.toMemberInfo = function toMemberInfo() {
-    return {
+    var memberInfo = {
         host: this.host,
         port: this.port,
         status: this.status,
         incarnationNumber: this.incarnationNumber,
     };
+
+    if (this.labels) {
+        // the easiest way to get the labels in the join response.
+        if (!memberInfo.extraFields) {
+            memberInfo.extraFields = {};
+        }
+        memberInfo.extraFields.labels = this.labels;
+    }
+
+    return memberInfo;
 };
 
 FakeNode.prototype.changeEndpoint = function modifyEndpoint(endpoint, handler) {
@@ -127,6 +137,8 @@ FakeNode.prototype.changeEndpoint = function modifyEndpoint(endpoint, handler) {
 // Useful, e.g., for partitioning tests.
 FakeNode.prototype.joinHandler = function joinHandler(req, res, arg2, arg3) {
     var membership = this.membership || this.coordinator.getMembership();
+
+    console.log("membership:",JSON.stringify(membership, null, 2));
     return handleJoin(req, res, this.toMemberInfo(), membership, this.coordinator.checksum);
 };
 

--- a/test/fake-node.js
+++ b/test/fake-node.js
@@ -137,8 +137,6 @@ FakeNode.prototype.changeEndpoint = function modifyEndpoint(endpoint, handler) {
 // Useful, e.g., for partitioning tests.
 FakeNode.prototype.joinHandler = function joinHandler(req, res, arg2, arg3) {
     var membership = this.membership || this.coordinator.getMembership();
-
-    console.log("membership:",JSON.stringify(membership, null, 2));
     return handleJoin(req, res, this.toMemberInfo(), membership, this.coordinator.checksum);
 };
 

--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -86,6 +86,12 @@ var features = {
         tests: [
             './partition-healing-tests'
         ]
+    },
+    'labels': {
+        mandatory: false,
+        tests: [
+            './labels'
+        ]
     }
 };
 

--- a/test/labels.js
+++ b/test/labels.js
@@ -110,7 +110,7 @@ test2('ringpop should not accept labels for a node with a lower incarnation numb
 );
 
 // The most likely assert to fail will be the last assert in this test where the
-// winning labels are compaired to the labels that were chosen after the first
+// winning labels are compared to the labels that were chosen after the first
 // round of label gossipping
 test2('ringpop should deterministically pick labels on conflict', getClusterSizes(2), 20000,
     prepareCluster(function(t, tc, n) {
@@ -119,7 +119,7 @@ test2('ringpop should deterministically pick labels on conflict', getClusterSize
 
         // two pairs of labels
         var labels1 = { "hello": "world" };
-        var labels2 = { "hello": "goodbey" };
+        var labels2 = { "hello": "goodbye" };
 
         return [
             // send the sut the first pair of labels on inc+1, these will always
@@ -214,7 +214,7 @@ test2('different labels should be accepted on a higher incarnation number', getC
 
         // two pairs of labels
         var labels1 = { "hello": "world" };
-        var labels2 = { "hello": "goodbey" };
+        var labels2 = { "hello": "goodbye" };
 
         return [
             // feed the sut with the first pair of labels
@@ -315,7 +315,7 @@ function testLabelOverrideOnStatusChange(firstStatus, secondStatus) {
 
             // two pairs of labels
             var labels1 = { "hello": "world" };
-            var labels2 = { "hello": "goodbey" };
+            var labels2 = { "hello": "goodbye" };
 
             return [
                 // feed the sut with the first pair of labels

--- a/test/labels.js
+++ b/test/labels.js
@@ -295,10 +295,11 @@ test2('ringpop doesn\'t reincarnate if it hears the wrong labels that are not pr
             sourceIx: 0,
             subjectIx: 'sut',
             status: 'alive',
-            // the hash for these labels is 1613250528 which is higher than 0
+            // the hash for these labels is -1494888142 which is lower than 0
             // since it will not be preferred ringpop will ignore the gossip
             labels: {
-                "hello": "world"
+                "hello": "world",
+                "foo":   "bar"
             }
         }),
         dsl.waitForPingResponse(t, tc, 0, 1, true),
@@ -314,12 +315,11 @@ test2('ringpop reincarnates if it hears the wrong labels', getClusterSizes(2), 2
             sourceIx: 0,
             subjectIx: 'sut',
             status: 'alive',
-            // the hash for these labels is -1494888142 which is lower than 0
+            // the hash for these labels is 1613250528 which is higher than 0
             // this causes the node to prefere this set of labels over his own,
             // which will trigger a reincarnation.
             labels: {
-                "hello": "world",
-                "foo":   "bar"
+                "hello": "world"
             }
         }),
         dsl.waitForPingResponse(t, tc, 0, 1, true),

--- a/test/labels.js
+++ b/test/labels.js
@@ -246,48 +246,6 @@ test2('different labels should be accepted on a higher incarnation number', getC
     })
 );
 
-// since nodes might miss updates on changes they should always accept labels if
-// the status updates, even if these labels differ from the labels that were
-// previously known to the node.
-function testLabelOverrideOnStatusChange(firstStatus, secondStatus) {
-    test2('different labels should be accepted on a state override from ' + firstStatus + ' to ' + secondStatus , getClusterSizes(2), 20000,
-        prepareCluster(function(t, tc, n) {
-
-            // two pairs of labels
-            var labels1 = { "hello": "world" };
-            var labels2 = { "hello": "goodbey" };
-
-            return [
-                // feed the sut with the first pair of labels
-                dsl.changeStatus(t, tc, 0, 1, {
-                    subjectIncNoDelta: +1,
-                    status: firstStatus,
-                    labels: labels1,
-                }),
-                dsl.waitForPingResponse(t, tc, 0, 0, true),
-
-                // assert that the first pair is accepted
-                dsl.assertMembership(t, tc, {
-                    1: { labels: labels1 }
-                }),
-
-                // feed the sut with the second pair of labels
-                dsl.changeStatus(t, tc, 0, 1, {
-                    subjectIncNoDelta: +1,
-                    status: secondStatus,
-                    labels: labels2,
-                }),
-                dsl.waitForPingResponse(t, tc, 0, 0, true),
-
-                // assert that the second pair is accepted
-                dsl.assertMembership(t, tc, {
-                    1: { labels: labels2 }
-                }),
-            ];
-        })
-    );
-};
-
 test2('ringpop doesn\'t reincarnate if it hears the wrong labels that are not preferred', getClusterSizes(2), 20000,
     prepareCluster(function(t, tc, n) { return [
         // do not disable node
@@ -347,3 +305,45 @@ testLabelOverrideOnStatusChange('faulty', 'tombstone');
 
 // begin with leave node
 testLabelOverrideOnStatusChange('leave', 'tombstone');
+
+// since nodes might miss updates on changes they should always accept labels if
+// the status updates, even if these labels differ from the labels that were
+// previously known to the node.
+function testLabelOverrideOnStatusChange(firstStatus, secondStatus) {
+    test2('different labels should be accepted on a state override from ' + firstStatus + ' to ' + secondStatus , getClusterSizes(2), 20000,
+        prepareCluster(function(t, tc, n) {
+
+            // two pairs of labels
+            var labels1 = { "hello": "world" };
+            var labels2 = { "hello": "goodbey" };
+
+            return [
+                // feed the sut with the first pair of labels
+                dsl.changeStatus(t, tc, 0, 1, {
+                    subjectIncNoDelta: +1,
+                    status: firstStatus,
+                    labels: labels1,
+                }),
+                dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+                // assert that the first pair is accepted
+                dsl.assertMembership(t, tc, {
+                    1: { labels: labels1 }
+                }),
+
+                // feed the sut with the second pair of labels
+                dsl.changeStatus(t, tc, 0, 1, {
+                    subjectIncNoDelta: +1,
+                    status: secondStatus,
+                    labels: labels2,
+                }),
+                dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+                // assert that the second pair is accepted
+                dsl.assertMembership(t, tc, {
+                    1: { labels: labels2 }
+                }),
+            ];
+        })
+    );
+};

--- a/test/labels.js
+++ b/test/labels.js
@@ -1,0 +1,304 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var _ = require('lodash');
+
+var dsl = require('./ringpop-assert');
+var events = require('./events');
+var getClusterSizes = require('./it-tests').getClusterSizes;
+var prepareCluster = require('./test-util').prepareCluster;
+var prepareWithStatus = require('./test-util').prepareWithStatus;
+var test2 = require('./test-util').test2;
+
+test2('ringpop should accept labels that are present in the bootstrap list', getClusterSizes(2), 20000, function init(t, tc, callback) {
+    // insert labels into the node before the sut is bootstrapped
+    tc.fakeNodes[0].labels = {
+        "hello": "world"
+    };
+    callback();
+}, prepareCluster(function(t, tc, n) { return [
+        dsl.assertStats(t, tc, n+1, 0, 0, {
+            0: {
+                labels: { "hello": "world" }
+            }
+        }),
+    ];})
+);
+
+test2('ringpop should accept labels for a node with a higher incarnation number from the node itself', getClusterSizes(2), 20000,
+    prepareCluster(function(t, tc, n) { return [
+        // feed the sut with label information for nodeIx 0
+        dsl.changeStatus(t, tc, 0, 0, {
+            subjectIncNoDelta: +1,
+            status: 'alive',
+            labels: {
+                "hello": "world"
+            },
+        }),
+        dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+        // assert that nodeIx 0 has its labels set on the sut
+        dsl.assertStats(t, tc, n+1, 0, 0, {
+            0: {
+                labels: {
+                    "hello": "world"
+                }
+            }
+        }),
+    ];})
+);
+
+test2('ringpop should accept labels for a node with a higher incarnation number from another node', getClusterSizes(2), 20000,
+    prepareCluster(function(t, tc, n) { return [
+        // feed the sut with label information for nodeIx 0
+        dsl.changeStatus(t, tc, 0, 1, {
+            subjectIncNoDelta: +1,
+            status: 'alive',
+            labels: {
+                "hello": "world"
+            },
+        }),
+        dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+        // assert that nodeIx 0 has its labels set on the sut
+        dsl.assertStats(t, tc, n+1, 0, 0, {
+            1: {
+                labels: {
+                    "hello": "world"
+                }
+            }
+        }),
+    ];})
+);
+
+test2('ringpop should not accept labels for a node with a lower incarnation number', getClusterSizes(2), 20000,
+    prepareCluster(function(t, tc, n) { return [
+        // feed the sut with label information for nodeIx 0
+        dsl.changeStatus(t, tc, 0, 1, {
+            subjectIncNoDelta: -1,
+            status: 'alive',
+            labels: {
+                "hello": "world"
+            },
+        }),
+        dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+        // assert that nodeIx 0 has its labels set on the sut
+        dsl.assertStats(t, tc, n+1, 0, 0, {
+            1: {
+                labels: undefined
+            }
+        }),
+    ];})
+);
+
+// The most likely assert to fail will be the last assert in this test where the
+// winning labels are compaired to the labels that were chosen after the first
+// round of label gossipping
+test2('ringpop should deterministically pick labels on conflict', getClusterSizes(2), 20000,
+    prepareCluster(function(t, tc, n) {
+        // keep track of the labels that won the first time around
+        var winningLabels = {};
+
+        // two pairs of labels
+        var labels1 = { "hello": "world" };
+        var labels2 = { "hello": "goodbey" };
+
+        return [
+            // send the sut the first pair of labels on inc+1, these will always
+            // be accepted because the incarnation number is higher
+            dsl.changeStatus(t, tc, 0, 1, {
+                subjectIncNoDelta: +1,
+                status: 'alive',
+                labels: labels1,
+            }),
+            dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+            // make sure these labels are accepted
+            dsl.assertMembership(t, tc, {
+                1: {
+                    labels: labels1
+                }
+            }),
+
+            // send the sut the second pair of labels on the same inc # as before
+            // these might or might not be accepted depending on the rules to be
+            // determined for deterministically picking 1 pair of labels
+            dsl.changeStatus(t, tc, 0, 1, {
+                subjectIncNoDelta: +1,
+                status: 'alive',
+                labels: labels2,
+            }),
+            dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+            // use a function to get a reference back to the member status
+            // returned for the node and store the labels that were chosen as
+            // the winning labels
+            dsl.assertMembership(t, tc, {
+                1: function storeWinningLabels(memberStatus) {
+                    // copy the winning labels into the placeholder object since
+                    // it needs to be passed to the validator function below on
+                    // test construction time.
+                    _.extend(winningLabels, memberStatus.labels,{winning:true});
+
+                    // to prevent the assertion happening in assert membership
+                    // we return true to indicate the 'test' passed.
+                    return true;
+                }
+            }),
+
+            // ================
+            //     MID WAY
+            // ================
+            // now that we have established which pair was chosen in the first
+            // round we are going to do the same on a higher incarnation number
+            // in the other order.
+
+            // first send the second pair
+            dsl.changeStatus(t, tc, 0, 1, {
+                subjectIncNoDelta: +2,
+                status: 'alive',
+                labels: labels2,
+            }),
+            dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+            // make sure these labels are accepted
+            dsl.assertMembership(t, tc, {
+                1: {
+                    labels: labels2
+                }
+            }),
+
+            // sending the first pair
+            dsl.changeStatus(t, tc, 0, 1, {
+                subjectIncNoDelta: +2,
+                status: 'alive',
+                labels: labels1,
+            }),
+            dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+            // validate that the second iteration picked the same winning labels
+            // as the first iteration to ensure convergence when there are
+            // conflicting labels being gossipped around.
+            dsl.assertMembership(t, tc, {
+                1: {
+                    labels: winningLabels
+                }
+            }),
+        ];
+    })
+);
+
+test2('different labels should be accepted on a higher incarnation number', getClusterSizes(2), 20000,
+    prepareCluster(function(t, tc, n) {
+
+        // two pairs of labels
+        var labels1 = { "hello": "world" };
+        var labels2 = { "hello": "goodbey" };
+
+        return [
+            // feed the sut with the first pair of labels
+            dsl.changeStatus(t, tc, 0, 1, {
+                subjectIncNoDelta: +1,
+                status: 'alive',
+                labels: labels1,
+            }),
+            dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+            // assert that the first pair is accepted
+            dsl.assertMembership(t, tc, {
+                1: { labels: labels1 }
+            }),
+
+             // feed the sut with the second pair of labels
+            dsl.changeStatus(t, tc, 0, 1, {
+                subjectIncNoDelta: +2,
+                status: 'alive',
+                labels: labels2,
+            }),
+            dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+            // assert that the second pair is accepted
+            dsl.assertMembership(t, tc, {
+                1: { labels: labels2 }
+            }),
+        ];
+    })
+);
+
+// since nodes might miss updates on changes they should always accept labels if
+// the status updates, even if these labels differ from the labels that were
+// previously known to the node.
+function testLabelOverrideOnStatusChange(firstStatus, secondStatus) {
+    test2('different labels should be accepted on a state override from ' + firstStatus + ' to ' + secondStatus , getClusterSizes(2), 20000,
+        prepareCluster(function(t, tc, n) {
+
+            // two pairs of labels
+            var labels1 = { "hello": "world" };
+            var labels2 = { "hello": "goodbey" };
+
+            return [
+                // feed the sut with the first pair of labels
+                dsl.changeStatus(t, tc, 0, 1, {
+                    subjectIncNoDelta: +1,
+                    status: firstStatus,
+                    labels: labels1,
+                }),
+                dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+                // assert that the first pair is accepted
+                dsl.assertMembership(t, tc, {
+                    1: { labels: labels1 }
+                }),
+
+                // feed the sut with the second pair of labels
+                dsl.changeStatus(t, tc, 0, 1, {
+                    subjectIncNoDelta: +1,
+                    status: secondStatus,
+                    labels: labels2,
+                }),
+                dsl.waitForPingResponse(t, tc, 0, 0, true),
+
+                // assert that the second pair is accepted
+                dsl.assertMembership(t, tc, {
+                    1: { labels: labels2 }
+                }),
+            ];
+        })
+    );
+};
+
+// begin with alive node
+testLabelOverrideOnStatusChange('alive', 'suspect');
+testLabelOverrideOnStatusChange('alive', 'faulty');
+testLabelOverrideOnStatusChange('alive', 'leave');
+testLabelOverrideOnStatusChange('alive', 'tombstone');
+
+// begin with suspect node
+testLabelOverrideOnStatusChange('suspect', 'faulty');
+testLabelOverrideOnStatusChange('suspect', 'leave');
+testLabelOverrideOnStatusChange('suspect', 'tombstone');
+
+// begin with faulty node
+testLabelOverrideOnStatusChange('faulty', 'leave');
+testLabelOverrideOnStatusChange('faulty', 'tombstone');
+
+// begin with leave node
+testLabelOverrideOnStatusChange('leave', 'tombstone');

--- a/test/labels.js
+++ b/test/labels.js
@@ -142,7 +142,10 @@ test2('ringpop should deterministically pick labels on conflict', getClusterSize
             // these might or might not be accepted depending on the rules to be
             // determined for deterministically picking 1 pair of labels
             dsl.changeStatus(t, tc, 0, 1, {
-                subjectIncNoDelta: +1,
+                // this time it should not increment the incarnation number as
+                // it needs to be gossiped with the same version to see which of
+                // the two states wins.
+                subjectIncNoDelta: 0,
                 status: 'alive',
                 labels: labels2,
             }),
@@ -156,7 +159,7 @@ test2('ringpop should deterministically pick labels on conflict', getClusterSize
                     // copy the winning labels into the placeholder object since
                     // it needs to be passed to the validator function below on
                     // test construction time.
-                    _.extend(winningLabels, memberStatus.labels,{winning:true});
+                    _.extend(winningLabels, memberStatus.labels);
 
                     // to prevent the assertion happening in assert membership
                     // we return true to indicate the 'test' passed.
@@ -173,7 +176,7 @@ test2('ringpop should deterministically pick labels on conflict', getClusterSize
 
             // first send the second pair
             dsl.changeStatus(t, tc, 0, 1, {
-                subjectIncNoDelta: +2,
+                subjectIncNoDelta: +1,
                 status: 'alive',
                 labels: labels2,
             }),
@@ -188,7 +191,7 @@ test2('ringpop should deterministically pick labels on conflict', getClusterSize
 
             // sending the first pair
             dsl.changeStatus(t, tc, 0, 1, {
-                subjectIncNoDelta: +2,
+                subjectIncNoDelta: 0,
                 status: 'alive',
                 labels: labels1,
             }),

--- a/test/labels.js
+++ b/test/labels.js
@@ -295,11 +295,11 @@ test2('ringpop doesn\'t reincarnate if it hears the wrong labels that are not pr
             sourceIx: 0,
             subjectIx: 'sut',
             status: 'alive',
-            // the hash for these labels is -1494888142 which is lower than 0
+            // the hash for these labels is -1017766696 which is lower than 0
             // since it will not be preferred ringpop will ignore the gossip
             labels: {
                 "hello": "world",
-                "foo":   "bar"
+                "foo":   "baz"
             }
         }),
         dsl.waitForPingResponse(t, tc, 0, 1, true),

--- a/test/membership-checksum.js
+++ b/test/membership-checksum.js
@@ -36,8 +36,23 @@ function generateChecksumString(members) {
 
             if (member.labels) {
                 Object.keys(member.labels).forEach(function (key) {
-                    var labelStr = key + '=' + member.labels[key];
-                    labelChecksum ^= farmhash.fingerprint32(labelStr);
+                    var keyBuffer = new Buffer(key);
+                    var valueBuffer = new Buffer(member.labels[key]);
+
+                    var keyLength = new Buffer(4)
+                    keyLength.writeInt32BE(keyBuffer.length, 0)
+
+                    var valueLength = new Buffer(4)
+                    valueLength.writeInt32BE(valueBuffer.length, 0)
+
+                    var labelBuffer = Buffer.concat([
+                        keyLength,
+                        keyBuffer,
+                        valueLength,
+                        valueBuffer
+                    ]);
+
+                    labelChecksum ^= farmhash.fingerprint32(labelBuffer);
                 });
             }
 

--- a/test/membership-checksum.js
+++ b/test/membership-checksum.js
@@ -36,7 +36,7 @@ function generateChecksumString(members) {
 
             if (member.labels) {
                 Object.keys(member.labels).forEach(function (key) {
-                    var labelStr = '/' + key + '/' + member.labels[key];
+                    var labelStr = key + '=' + member.labels[key];
                     labelChecksum ^= farmhash.fingerprint32(labelStr);
                 });
             }

--- a/test/membership-checksum.js
+++ b/test/membership-checksum.js
@@ -31,9 +31,21 @@ function generateChecksumString(members) {
         })
         .map(function (member) {
             var address = member.address || (member.host + ':' + member.port);
+            var labelsStr = ''
+
+            if (member.labels) {
+                var keys = Object.keys(member.labels);
+                keys.sort();
+
+                keys.forEach(function (key) {
+                    labelsStr += '-' + key + '-' + member.labels[key];
+                });
+            }
+
             return address +
                     member.status +
-                    member.incarnationNumber
+                    member.incarnationNumber +
+                    labelsStr
         })
         .value()
         .sort()

--- a/test/membership-checksum.js
+++ b/test/membership-checksum.js
@@ -36,23 +36,21 @@ function generateChecksumString(members) {
 
             if (member.labels) {
                 Object.keys(member.labels).forEach(function (key) {
-                    var keyBuffer = new Buffer(key);
-                    var valueBuffer = new Buffer(member.labels[key]);
+                    var value = member.labels[key];
 
-                    var keyLength = new Buffer(4)
-                    keyLength.writeInt32BE(keyBuffer.length, 0)
+                    var keyLength = Buffer.byteLength(key);
+                    var valueLength = Buffer.byteLength(value);
 
-                    var valueLength = new Buffer(4)
-                    valueLength.writeInt32BE(valueBuffer.length, 0)
+                    var pos = 0;
+                    var buf = new Buffer(8 + keyLength + valueLength);
+                    buf.writeInt32BE(keyLength, pos);
+                    pos += 4
+                    pos += buf.write(key, pos);
+                    buf.writeInt32BE(valueLength, pos);
+                    pos += 4
+                    pos += buf.write(value, pos);
 
-                    var labelBuffer = Buffer.concat([
-                        keyLength,
-                        keyBuffer,
-                        valueLength,
-                        valueBuffer
-                    ]);
-
-                    labelChecksum ^= farmhash.fingerprint32(labelBuffer);
+                    labelChecksum ^= farmhash.fingerprint32(buf);
                 });
             }
 

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -222,16 +222,21 @@ function sendPings(t, tc, nodeIxs) {
     });
 }
 
-function changeStatus(t, tc, sourceIx, subjectIx, status, subjectIncNoDelta) {
-    var ping = sendPing(t, tc, sourceIx, {
+function changeStatus(t, tc, sourceIx, subjectIx, statusOrOptions, subjectIncNoDelta) {
+    if (typeof statusOrOptions !== 'object') {
+        statusOrOptions = {
+            status: statusOrOptions,
+            subjectIncNoDelta: subjectIncNoDelta || 0,
+        };
+    }
+
+    var ping = sendPing(t, tc, sourceIx, _.extend({
         sourceIx: sourceIx,
         subjectIx: subjectIx,
-        status: status,
-        subjectIncNoDelta: subjectIncNoDelta || 0
-    });
+    }, statusOrOptions));
 
     var f = _.once(function (list, cb) {
-        tc.fakeNodes[subjectIx].status = status;
+        tc.fakeNodes[subjectIx].status = statusOrOptions.status;
         return ping(list, cb);
     });
     f.callerName = 'changeStatus';
@@ -487,11 +492,18 @@ function waitForStatsAssertMembership(t, tc, members) {
         _.forEach(members, function(member, i) {
             // find member i in statsMembers
             var ix = _.findIndex(statsMembers, {address: tc.fakeNodes[i].getHostPort()});
-            received = statsMembers[ix];
-            expected = member;
-            _.forEach(member, function(value, field) {
-                t.equal(statsMembers[ix][field], value, 'assert membership', errDetails({ expected: expected, received: received}));
-            });
+            var received = statsMembers[ix];
+
+            if (typeof member === 'function') {
+                // use the function to test the received member object
+                t.ok(member(received), 'assert membership via closure: ' + (member.name||'<anonymous>'));
+            } else {
+                // test the received object to the expected object field by field
+                var expected = member;
+                _.forEach(member, function(value, field) {
+                    t.deepEqual(statsMembers[ix][field], value, 'assert membership', errDetails({ expected: expected, received: received}));
+                });
+            }
         });
 
         _.pullAt(list, ix);
@@ -881,6 +893,11 @@ function piggyback(tc, opts) {
     update.id = opts.id || uuid.v4();
     update.status = opts.status;
     update.tombstone = opts.tombstone || false;
+
+    // copy labels to the piggybacked ping when present
+    if (opts.labels) {
+        update.labels = opts.labels;
+    }
 
     if(opts.sourceIx === 'sut') {
         update.source = tc.sutHostPort;


### PR DESCRIPTION
This PR adds tests for the labels feature in ringpop to the integration test suit. Currently the feature is only implemented in ringpop-go and the test is a non mandatory test for now and enabled via the `--enable-feature labels` command line option.