### PR TITLE
Fix flappy integration test

### DIFF
--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -804,8 +804,10 @@ function validate(t, tc, scheme, deadline) {
     var cursor = 0;
     var allEvents = [];
     var eventList = [];
+    var timedOut = false;
 
     var timer = setTimeout(function() {
+        timedOut = true;
         t.fail('timeout');
         tc.removeAllListeners('event');
         tc.removeAllListeners('sut-died');
@@ -830,6 +832,7 @@ function validate(t, tc, scheme, deadline) {
     // to the next function.
     var inProgress = false;
     var progressFromCursor = function() {
+        if (timedOut) return;
         if (inProgress) return;
         inProgress = true;
 

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -74,7 +74,10 @@ function waitForPingReqs(t, tc, n) {
     };
 }
 
-function waitForPing(t, tc) {
+function waitForPing(t, tc, consume) {
+    if (consume === undefined) {
+        consume = true;
+    }
     return function waitForPing(list, cb) {
         var index = _.findIndex(list, {
             type: events.Types.Ping,
@@ -86,8 +89,9 @@ function waitForPing(t, tc) {
             return cb(null);
         }
 
-        list.splice(index, 1); // remove ping from list
-
+        if (consume) {
+            list.splice(index, 1); // remove ping from list
+        }
         return cb(list);
     };
 }

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -98,6 +98,8 @@ TestCoordinator.prototype.lookup = function(key) {
 
     var matchingNode;
     var matchingHash;
+    var minimumNode;
+    var minimumHash;
 
     var hash = farmhash.fingerprint32(key);
 
@@ -105,7 +107,6 @@ TestCoordinator.prototype.lookup = function(key) {
         if (!matchingNode) return true; // 1 node is better than no node
 
         if (hash <= newHash && newHash < matchingHash) return true; // new hash is closer to the current best match
-        if (matchingHash <= hash && hash <= newHash) return true; // the matchingHash wraps around, and new hash is a better match to hash
 
         return false;
     }
@@ -121,6 +122,10 @@ TestCoordinator.prototype.lookup = function(key) {
         for (var i=0; i<self.replicaPoints; i++) {
             var currentHash = farmhash.fingerprint32(hostPort + i);
 
+            if (minimumNode === undefined || currentHash < minimumHash)  {
+                minimumNode = hostPort;
+                minimumHash = currentHash;
+            }
             if (isBetterMatch(currentHash)) {
                 matchingNode = hostPort;
                 matchingHash = currentHash;
@@ -128,6 +133,11 @@ TestCoordinator.prototype.lookup = function(key) {
         }
     });
 
+    // wrap around
+    if (matchingHash < hash) {
+        matchingHash = minimumHash;
+        matchingNode = minimumNode;
+    }
     console.log("hash:", hash, "matchingHash:", matchingHash);
 
     return matchingNode;

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -121,7 +121,7 @@ function testStateTransitions(ns, initial, newState, finalState, incNoDelta, sta
 function prepareCluster(insert_fns) {
     return function(t, tc, n) {
         return [
-            dsl.waitForPing(t, tc),
+            dsl.waitForPing(t, tc, false),
             dsl.waitForJoins(t, tc, n),
             dsl.assertDetectChecksumMethod(t, tc),
             dsl.assertStats(t, tc, n+1, 0, 0),

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -121,7 +121,11 @@ function testStateTransitions(ns, initial, newState, finalState, incNoDelta, sta
 function prepareCluster(insert_fns) {
     return function(t, tc, n) {
         return [
+            // By waiting for the first ping we make sure the SUT is ready to go.
+            // We don't consume it so other tests (especially the ping-tests)
+            // can still assert implementation details related to ping distribution.
             dsl.waitForPing(t, tc, false),
+
             dsl.waitForJoins(t, tc, n),
             dsl.assertDetectChecksumMethod(t, tc),
             dsl.assertStats(t, tc, n+1, 0, 0),

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -121,12 +121,14 @@ function testStateTransitions(ns, initial, newState, finalState, incNoDelta, sta
 function prepareCluster(insert_fns) {
     return function(t, tc, n) {
         return [
-            dsl.waitForJoins(t, tc, n),
-
             // By waiting for the first ping we make sure the SUT is ready to go.
             // We don't consume it so other tests (especially the ping-tests)
             // can still assert implementation details related to ping distribution.
             dsl.waitForPing(t, tc, false),
+
+            // We're waiting for joins AFTER the first ping so we're able to detect
+            // if there are too many joins.
+            dsl.waitForJoins(t, tc, n),
 
             dsl.assertDetectChecksumMethod(t, tc),
             dsl.assertStats(t, tc, n+1, 0, 0),

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -128,7 +128,6 @@ function prepareCluster(insert_fns) {
             // can still assert implementation details related to ping distribution.
             dsl.waitForPing(t, tc, false),
 
-            //dsl.waitForJoins(t, tc, n),
             dsl.assertDetectChecksumMethod(t, tc),
             dsl.assertStats(t, tc, n+1, 0, 0),
             insert_fns(t, tc, n),

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -121,8 +121,9 @@ function testStateTransitions(ns, initial, newState, finalState, incNoDelta, sta
 function prepareCluster(insert_fns) {
     return function(t, tc, n) {
         return [
-            dsl.assertDetectChecksumMethod(t, tc),
+            dsl.waitForPing(t, tc),
             dsl.waitForJoins(t, tc, n),
+            dsl.assertDetectChecksumMethod(t, tc),
             dsl.assertStats(t, tc, n+1, 0, 0),
             insert_fns(t, tc, n),
             dsl.expectOnlyPingsAndPingReqs(t, tc),

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -121,12 +121,14 @@ function testStateTransitions(ns, initial, newState, finalState, incNoDelta, sta
 function prepareCluster(insert_fns) {
     return function(t, tc, n) {
         return [
+            dsl.waitForJoins(t, tc, n),
+
             // By waiting for the first ping we make sure the SUT is ready to go.
             // We don't consume it so other tests (especially the ping-tests)
             // can still assert implementation details related to ping distribution.
             dsl.waitForPing(t, tc, false),
 
-            dsl.waitForJoins(t, tc, n),
+            //dsl.waitForJoins(t, tc, n),
             dsl.assertDetectChecksumMethod(t, tc),
             dsl.assertStats(t, tc, n+1, 0, 0),
             insert_fns(t, tc, n),


### PR DESCRIPTION
This PR fixes three issues:
- [x] A race condition where a test completes and times out at the same time: this is fixed by breaking out the event-loop early after a time out.
- [x] Start running the test before the SUT is ready: fixed by waiting for an initial ping from the SUT.
- [x] The implementation of lookup in the integration tests is incorrect. Sometimes it returns an incorrect result