### PR TITLE
Allow multiple checksums

### DIFF
--- a/schema/admin-stats-response.json
+++ b/schema/admin-stats-response.json
@@ -115,6 +115,14 @@
                 "checksum": {
                     "type": "number"
                 },
+                "checksums": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "type": "number"
+                        }
+                    }
+                },
                 "servers": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
uber/ringpop-go#192 adds support for multiple checksums. This PR makes the required changes to the protocol schema.