### PR TITLE
Allow initial labels

### DIFF
--- a/schema/protocol-join-request.json
+++ b/schema/protocol-join-request.json
@@ -14,6 +14,9 @@
         },
         "timeout": {
             "type": "number"
+        },
+        "labels": {
+            "$ref": "/Labels"
         }
     },
     "required": [

--- a/schema/protocol-join-response.json
+++ b/schema/protocol-join-response.json
@@ -26,6 +26,9 @@
                     "incarnationNumber": {
                         "type": "number"
                     },
+                    "labels": {
+                        "$ref": "/Labels"
+                    },
 
                     "timestamp": {
                         "type": "number"

--- a/test/partition-healing-tests.js
+++ b/test/partition-healing-tests.js
@@ -499,8 +499,9 @@ function checkSutMergedWithB(t, tc) {
                 var found_sut = _.find(changes, {address: sut_hostport, status: 'alive'});
                 if (found_a && found_sut) {
                     t.ok(true, "found alive a and sut");
-                    // XXX a bit inappropriate to set incarnation number here, but hey.
-                    tc.test_state['sutIncarnationNumber'] = found_sut.incarnationNumber
+                    // XXX a bit inappropriate to set internal state here, but hey.
+                    tc.test_state['sutIncarnationNumber'] = found_sut.incarnationNumber;
+                    tc.test_state['sutLabels'] = found_sut.labels;
                 }
                 cb(_.without(list, ping));
             }

--- a/test/protocol-join.js
+++ b/test/protocol-join.js
@@ -40,7 +40,8 @@ function getJoinResponsePayload(respondingNode, membershipList, checksumMethod) 
             source: responderHostPort,
             address: makeHostPort(member.host, member.port),
             status: member.status,
-            incarnationNumber: member.incarnationNumber
+            incarnationNumber: member.incarnationNumber,
+            labels: member.labels
         }, member.extraFields);
     });
 

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -52,8 +52,10 @@ function waitForJoins(t, tc, n) {
         t.equals(joins.length, n, 'check number of joins',
             errDetails({journal: _.pluck(list, 'endpoint')}));
 
-        //XXX: a bit inappropriate to get sutIncarnationNumber like this
-        tc.test_state['sutIncarnationNumber'] = safeJSONParse(joins[0].arg3).incarnationNumber;
+        //XXX: a bit inappropriate to set internal state like this
+        var joinRequest = safeJSONParse(joins[0].arg3);
+        tc.test_state['sutIncarnationNumber'] = joinRequest.incarnationNumber;
+        tc.test_state['sutLabels'] = joinRequest.labels;
         cb(_.reject(list, {type: events.Types.Join}));
     };
 }
@@ -673,6 +675,7 @@ function waitForStatsAssertBumpedIncarnationNumber(t, tc) {
             'sut bumped incarnation number to ' + member.incarnationNumber,
             errDetails({ old: tc.test_state['sutIncarnationNumber'], new: member.incarnationNumber}));
         tc.test_state['sutIncarnationNumber'] = member.incarnationNumber;
+        tc.test_state['sutLabels'] = member.labels;
 
         _.pullAt(list, ix);
         cb(list);
@@ -959,17 +962,19 @@ function piggyback(tc, opts) {
     update.status = opts.status;
     update.tombstone = opts.tombstone || false;
 
-    // copy labels to the piggybacked ping when present
-    if (opts.labels) {
-        update.labels = opts.labels;
-    }
-
     if(opts.sourceIx === 'sut') {
         update.source = tc.sutHostPort;
         update.sourceIncarnationNumber = tc.test_state['sutIncarnationNumber'];
+        update.labels = tc.test_state['sutLabels'];
     } else {
         update.source = tc.fakeNodes[opts.sourceIx].getHostPort();
         update.sourceIncarnationNumber = tc.fakeNodes[opts.sourceIx].incarnationNumber;
+        update.labels = tc.fakeNodes[opts.sourceIx].labels;
+    }
+
+    // copy labels to the piggybacked ping when present
+    if (opts.labels) {
+        update.labels = opts.labels;
     }
 
     if (opts.sourceIncNoDetla !== undefined) {

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -53,7 +53,7 @@ function waitForJoins(t, tc, n) {
             errDetails({journal: _.pluck(list, 'endpoint')}));
 
         //XXX: a bit inappropriate to set internal state like this
-        var joinRequest = safeJSONParse(joins[0].arg3);
+        var joinRequest = joins[0].body
         tc.test_state['sutIncarnationNumber'] = joinRequest.incarnationNumber;
         tc.test_state['sutLabels'] = joinRequest.labels;
         cb(_.reject(list, {type: events.Types.Join}));

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -275,12 +275,14 @@ TestCoordinator.prototype.getSUTAsMember = function getSUTAsMember() {
     var host = this.sutHostPort.split(':')[0];
     var port = this.sutHostPort.split(':')[1];
     var incNo = this.test_state['sutIncarnationNumber'];
+    var labels = this.test_state['sutLabels'];
 
     return {
         host: host,
         port: port,
         status: 'alive',
-        incarnationNumber: incNo
+        incarnationNumber: incNo,
+        labels: labels
     };
 };
 


### PR DESCRIPTION
A pre-requirement for identity-carryover is support to set labels before bootstrapping. 
To improve support for labels and extend this with labels set before bootstrapping, 
- Add labels to `join-request` and `join-response` schema.
- store and propagate labels from SUT and fake nodes correctly