### PR TITLE
Add integration tests for identities

### DIFF
--- a/test/identity.js
+++ b/test/identity.js
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var _ = require('lodash');
+
+var dsl = require('./ringpop-assert');
+var events = require('./events');
+var getClusterSizes = require('./it-tests').getClusterSizes;
+var prepareCluster = require('./test-util').prepareCluster;
+var prepareWithStatus = require('./test-util').prepareWithStatus;
+var test2 = require('./test-util').test2;
+
+test2('ringpop should set it\'s identity during bootstrap', getClusterSizes(2), 20000, function init(t, tc, callback) {
+        tc.sutIdentity = 'identity';
+
+        callback();
+    }, prepareCluster(function(t, tc, n) {
+        return [
+            dsl.assertStats(t, tc, n + 1, 0, 0, {
+                'sut': {
+                    labels: {"__identity": "identity"}
+                }
+            })
+        ];
+    })
+);
+
+test2('ringpop - with identity - full lookup returns correct values', getClusterSizes(1), 20000, function init(t, tc, callback) {
+    tc.sutIdentity = 'sut';
+    tc.fakeNodes[0].labels = {'__identity' : 'fake-node'}
+
+    callback();
+}, prepareCluster(function(t, tc, n) {
+    return dsl.assertFullHashring(t, tc, {0: 'fake-node', 'sut': 'sut'});
+}));
+
+test2('ringpop - when identity changes, hashring is updated', getClusterSizes(1), 20000, prepareCluster(function(t, tc, n) {
+    return [
+        dsl.assertFullHashring(t, tc),
+        dsl.changeStatus(t, tc, 0, 0, {
+            subjectIncNoDelta: +1,
+            status: 'alive',
+            labels: {
+                '__identity': 'identity'
+            }
+        }),
+        dsl.waitForPingResponse(t, tc, 0),
+        dsl.assertFullHashring(t, tc, {0: 'identity'}), // validate change from no identity to 'identity'
+        dsl.changeStatus(t, tc, 0, 0, {
+            subjectIncNoDelta: +1,
+            status: 'alive',
+            labels: {
+                '__identity': 'identity2'
+            }
+        }),
+        dsl.waitForPingResponse(t, tc, 0),
+        dsl.assertFullHashring(t, tc, {0: 'identity2'}), // validate change from 'identity' to 'identity2'
+
+        dsl.changeStatus(t, tc, 0, 0, {
+            subjectIncNoDelta: +1,
+            status: 'alive',
+            labels: {}
+        }),
+        dsl.waitForPingResponse(t, tc, 0),
+        dsl.assertFullHashring(t, tc) // validate change from 'identity2' to no identity
+    ]
+}));

--- a/test/it-tests.js
+++ b/test/it-tests.js
@@ -104,6 +104,12 @@ var features = {
         tests: [
             './lookup-tests'
         ]
+    },
+    'identity': {
+        mandatory: false,
+        tests: [
+            './identity'
+        ]
     }
 };
 

--- a/test/lookup-tests.js
+++ b/test/lookup-tests.js
@@ -32,15 +32,17 @@ test2('ringpop full lookup returns correct values', getClusterSizes(1), 20000, p
     });
 
     // Loop through all hostPorts
-    return _.map(hostPorts, function eachHostPort(hostPort) {
-        // And all replica points
-        return _.times(tc.replicaPoints, function eachReplicaPoint(index) {
+    var mapping = _.reduce(hostPorts, function(mapping, hostPort){
+        // and all replica points
+        _.times(tc.replicaPoints, function eachReplicaPoint(index){
             var replicaPoint = hostPort + index;
-
-            // And validate if a lookup on it results in the right hostPort
-            return dsl.assertLookup(t, tc, replicaPoint, hostPort);
+            // and add a mapping for the replica-point to the hostPort
+            mapping[replicaPoint] = hostPort;
         });
-    });
+        return mapping;
+    }, {});
+
+    return dsl.assertLookups(t, tc, mapping);
 }));
 
 test2('ringpop lookup of faulty member should return different member', getClusterSizes(2), 20000, prepareCluster(function(t, tc){

--- a/test/lookup-tests.js
+++ b/test/lookup-tests.js
@@ -26,23 +26,7 @@ var prepareCluster = require('./test-util').prepareCluster;
 var test2 = require('./test-util').test2;
 
 test2('ringpop full lookup returns correct values', getClusterSizes(1), 20000, prepareCluster(function(t, tc, n) {
-    var membership = tc.getMembership();
-    var hostPorts = _.map(membership, function(member) {
-        return member.host + ':' + member.port;
-    });
-
-    // Loop through all hostPorts
-    var mapping = _.reduce(hostPorts, function(mapping, hostPort){
-        // and all replica points
-        _.times(tc.replicaPoints, function eachReplicaPoint(index){
-            var replicaPoint = hostPort + index;
-            // and add a mapping for the replica-point to the hostPort
-            mapping[replicaPoint] = hostPort;
-        });
-        return mapping;
-    }, {});
-
-    return dsl.assertLookups(t, tc, mapping);
+    return dsl.assertFullHashring(t, tc);
 }));
 
 test2('ringpop lookup of faulty member should return different member', getClusterSizes(2), 20000, prepareCluster(function(t, tc){

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -577,7 +577,7 @@ function waitForStatsAssertMembership(t, tc, members) {
                 hostPort = tc.getSUTHostPort();
             } else {
                 // find member i in statsMembers
-                hostPort= _tc.fakeNodes[i].getHostPort();
+                hostPort = tc.fakeNodes[i].getHostPort();
             }
             var received = _.find(statsMembers, {address: hostPort});
 

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -64,6 +64,7 @@ function TestCoordinator(options) {
     this.sutHostPort = makeHostPort('127.0.0.1', _.random(10000, 30000));
     this.sutProgram = options.sut.program;
     this.sutInterpreter = options.sut.interpreter;
+    this.sutIdentity = undefined;
     this.suspectPeriod = 5000;
     this.faultyPeriod = 5000;
     this.tombstonePeriod = 5000;
@@ -172,6 +173,11 @@ TestCoordinator.prototype.startSUT = function startSUT() {
         program = this.sutInterpreter
         args.push(this.sutProgram)
     }
+
+    if (this.sutIdentity) {
+        args.push(util.format('--identity=%s', this.sutIdentity));
+    }
+
     args.push(util.format('--hosts=%s', this.hostsFile));
     args.push(util.format('--listen=%s', this.sutHostPort));
     args.push(util.format('--suspect-period=%d', this.suspectPeriod));


### PR DESCRIPTION
- Add support to specify the identity of the sut (required new version of testpop)
- Extracted full hashring mapping to it's own method for reuse
- add identity tests