### PR TITLE
Support improved replica point naming with identities

### DIFF
--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -484,7 +484,7 @@ function assertFullHashring(t, tc, identities) {
         _.times(tc.replicaPoints, function eachReplicaPoint(index) {
             var hostPort = member.host + ':' + member.port;
 
-            var identity = identityMapping[hostPort] || hostPort;
+            var identity = identityMapping[hostPort] ? identityMapping[hostPort] + '#' : hostPort;
             var replicaPoint = identity + index;
             // and add a mapping for the replica-point to the hostPort
             mapping[replicaPoint] = hostPort;


### PR DESCRIPTION
Together with supporting identities we can fix a longstanding bugs where replica-points can collide when there are multiple instances running on the same machine. 