### PR TITLE
Fix instructions to require modules

### DIFF
--- a/docs/programming_ringpop.md
+++ b/docs/programming_ringpop.md
@@ -9,7 +9,7 @@ an instance of TChannel, the underlying transport for Ringpop:
 
 **Node.js**
 ```js
-var TChannel = require('TChannel');
+var TChannel = require('tchannel');
 
 var tchannel = new TChannel();
 var subChannel = tchannel.makeSubChannel({


### PR DESCRIPTION
Changed `require('TChannel')` to `require('tchannel')`. The module name is correct in the latter.