### PR TITLE
Test state transitions

### DIFF
--- a/test/fake-node.js
+++ b/test/fake-node.js
@@ -251,6 +251,9 @@ FakeNode.prototype.requestPing = function requestPing(callback, piggybackData, b
             return;
         }
 
+        self.lastPingTime = Date.now();
+        self.coordinator.emit('ping.send', this, self.lastPingTime);
+
         self.channel.request({
             serviceName: 'ringpop',
             host: self.coordinator.sutHostPort,

--- a/test/fake-node.js
+++ b/test/fake-node.js
@@ -137,6 +137,7 @@ FakeNode.prototype.changeEndpoint = function modifyEndpoint(endpoint, handler) {
 // Useful, e.g., for partitioning tests.
 FakeNode.prototype.joinHandler = function joinHandler(req, res, arg2, arg3) {
     var membership = this.membership || this.coordinator.getMembership();
+    this.coordinator.emit('joined', this);
     return handleJoin(req, res, this.toMemberInfo(), membership, this.coordinator.checksum);
 };
 

--- a/test/join-tests.js
+++ b/test/join-tests.js
@@ -63,3 +63,36 @@ test2('join ringpop with fake node', getClusterSizes(), 20000,
         dsl.expectOnlyPings(t, tc),
     ];})
 );
+
+test2('5-second suspect to faulty window on join',
+    getClusterSizes(2),
+    20000,
+    function init(t, tc, callback) {
+        tc.addMembershipInformation('192.0.2.100:1234', 'suspect', 127);
+        callback();
+    },
+    prepareCluster({faulty: 1}, function(t, tc, n) {
+        return [
+            dsl.assertStats(t, tc, {
+                alive: n+1,
+                suspect: 1,
+                faulty: 0,
+                tombstone: 0
+            }),
+            dsl.wait(4000),
+            dsl.assertStats(t, tc, {
+                alive: n+1,
+                suspect: 1,
+                faulty: 0,
+                tombstone: 0
+            }),
+            dsl.wait(1100),
+            dsl.assertStats(t, tc, {
+                alive: n+1,
+                suspect: 0,
+                faulty: 1,
+                tombstone: 0
+            })
+        ];
+    })
+);

--- a/test/join-tests.js
+++ b/test/join-tests.js
@@ -71,7 +71,7 @@ test2('5-second suspect to faulty window on join',
         tc.addMembershipInformation('192.0.2.100:1234', 'suspect', 127);
         callback();
     },
-    prepareCluster({faulty: 1}, function(t, tc, n) {
+    prepareCluster({suspect: 1}, function(t, tc, n) {
         return [
             dsl.assertStats(t, tc, {
                 alive: n+1,

--- a/test/join-tests.js
+++ b/test/join-tests.js
@@ -79,20 +79,7 @@ test2('5-second suspect to faulty window on join',
                 faulty: 0,
                 tombstone: 0
             }),
-            dsl.wait(4000),
-            dsl.assertStats(t, tc, {
-                alive: n+1,
-                suspect: 1,
-                faulty: 0,
-                tombstone: 0
-            }),
-            dsl.wait(1100),
-            dsl.assertStats(t, tc, {
-                alive: n+1,
-                suspect: 0,
-                faulty: 1,
-                tombstone: 0
-            })
+            dsl.assertStateChange(t, tc, '192.0.2.100:1234', 'faulty', 5000)
         ];
     })
 );

--- a/test/join-tests.js
+++ b/test/join-tests.js
@@ -79,7 +79,7 @@ test2('5-second suspect to faulty window on join',
                 faulty: 0,
                 tombstone: 0
             }),
-            dsl.assertStateChange(t, tc, '192.0.2.100:1234', 'faulty', 5000)
+            dsl.assertStateChange(t, tc, '192.0.2.100:1234', 'faulty', 5000, true)
         ];
     })
 );

--- a/test/join-tests.js
+++ b/test/join-tests.js
@@ -73,12 +73,6 @@ test2('5-second suspect to faulty window on join',
     },
     prepareCluster({suspect: 1}, function(t, tc, n) {
         return [
-            dsl.assertStats(t, tc, {
-                alive: n+1,
-                suspect: 1,
-                faulty: 0,
-                tombstone: 0
-            }),
             dsl.assertStateChange(t, tc, '192.0.2.100:1234', 'faulty', 5000, true)
         ];
     })

--- a/test/ping-req-tests.js
+++ b/test/ping-req-tests.js
@@ -70,7 +70,7 @@ test2('become suspect through disabling ping response', getClusterSizes(2), 2000
 test2('5-second suspect to faulty window', getClusterSizes(2), 20000,
     prepareWithStatus(1, 'suspect', function(t, tc, n) { return [
         dsl.assertStats(t, tc, n, 1, 0, {1: {status: 'suspect'}}),
-        dsl.assertStateChange(t, tc, 1, 'faulty', 5000),
+        dsl.assertStateChange(t, tc, 1, 'faulty', 5000, false),
     ];})
 );
 

--- a/test/ping-req-tests.js
+++ b/test/ping-req-tests.js
@@ -70,10 +70,7 @@ test2('become suspect through disabling ping response', getClusterSizes(2), 2000
 test2('5-second suspect to faulty window', getClusterSizes(2), 20000,
     prepareWithStatus(1, 'suspect', function(t, tc, n) { return [
         dsl.assertStats(t, tc, n, 1, 0, {1: {status: 'suspect'}}),
-        dsl.wait(4000),
-        dsl.assertStats(t, tc, n, 1, 0, {1: {status: 'suspect'}}),
-        dsl.wait(1100),
-        dsl.assertStats(t, tc, n, 0, 1, {1: {status: 'faulty'}}),
+        dsl.assertStateChange(t, tc, 1, 'faulty', 5000),
     ];})
 );
 

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -89,10 +89,7 @@ test2('join cluster with tombstone flag in memberlist', getClusterSizes(2), 2000
 test2('5-second faulty to tombstone window', getClusterSizes(2), 20000,
     prepareWithStatus(1, 'faulty', function(t, tc, n) { return [
         dsl.assertStats(t, tc, {alive: n, faulty: 1}, {1: {status: 'faulty'}}),
-        dsl.wait(4000),
-        dsl.assertStats(t, tc, {alive: n, faulty: 1}, {1: {status: 'faulty'}}),
-        dsl.wait(1100),
-        dsl.assertStats(t, tc, {alive: n, tombstone: 1}, {1: {status: 'tombstone'}}),
+        dsl.assertStateChange(t, tc, 1, 'tombstone', 5000),
     ];})
 );
 
@@ -110,18 +107,7 @@ test2('5-second faulty to tombstone window on join',
                 faulty: 1,
                 tombstone: 0
             }),
-            dsl.wait(4000),
-            dsl.assertStats(t, tc, {
-                alive: n+1,
-                faulty: 1,
-                tombstone: 0
-            }),
-            dsl.wait(1100),
-            dsl.assertStats(t, tc, {
-                alive: n+1,
-                faulty: 0,
-                tombstone: 1
-            })
+            dsl.assertStateChange(t, tc, '192.0.2.100:1234', 'tombstone', 5000),
         ];
     })
 );

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -89,7 +89,7 @@ test2('join cluster with tombstone flag in memberlist', getClusterSizes(2), 2000
 test2('5-second faulty to tombstone window', getClusterSizes(2), 20000,
     prepareWithStatus(1, 'faulty', function(t, tc, n) { return [
         dsl.assertStats(t, tc, {alive: n, faulty: 1}, {1: {status: 'faulty'}}),
-        dsl.assertStateChange(t, tc, 1, 'tombstone', 5000),
+        dsl.assertStateChange(t, tc, 1, 'tombstone', 5000, false),
     ];})
 );
 
@@ -107,7 +107,7 @@ test2('5-second faulty to tombstone window on join',
                 faulty: 1,
                 tombstone: 0
             }),
-            dsl.assertStateChange(t, tc, '192.0.2.100:1234', 'tombstone', 5000),
+            dsl.assertStateChange(t, tc, '192.0.2.100:1234', 'tombstone', 5000, true),
         ];
     })
 );

--- a/test/reaping-faulty-nodes.js
+++ b/test/reaping-faulty-nodes.js
@@ -96,6 +96,36 @@ test2('5-second faulty to tombstone window', getClusterSizes(2), 20000,
     ];})
 );
 
+test2('5-second faulty to tombstone window on join',
+    getClusterSizes(2),
+    20000,
+    function init(t, tc, callback) {
+        tc.addMembershipInformation('192.0.2.100:1234', 'faulty', 127);
+        callback();
+    },
+    prepareCluster({faulty: 1}, function(t, tc, n) {
+        return [
+            dsl.assertStats(t, tc, {
+                alive: n+1,
+                faulty: 1,
+                tombstone: 0
+            }),
+            dsl.wait(4000),
+            dsl.assertStats(t, tc, {
+                alive: n+1,
+                faulty: 1,
+                tombstone: 0
+            }),
+            dsl.wait(1100),
+            dsl.assertStats(t, tc, {
+                alive: n+1,
+                faulty: 0,
+                tombstone: 1
+            })
+        ];
+    })
+);
+
 test2('5-second tombstone to evicted window', getClusterSizes(2), 20000,
     prepareWithStatus(1, 'tombstone', function(t, tc, n) { return [
         dsl.assertStats(t, tc, {alive: n, tombstone: 1}, {1: {status: 'tombstone'}}),

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -626,7 +626,7 @@ function assertStats(t, tc, statusCountsOralive, suspect, faulty, members) {
 }
 
 function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allowedJitter) {
-    allowedJitter = allowedJitter || 1500; //Default to 1500ms jitter
+    allowedJitter = allowedJitter || 2000; //Default to 2s jitter
 
     var address;
     if (typeof addressOrIndex === 'number') {

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -635,13 +635,7 @@ function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allo
         address = addressOrIndex;
     }
 
-    var start = null;
-
     return function assertStateChange(list, cb) {
-        // set start date on first evaluation.
-        if (start === null) {
-            start = new Date();
-        }
         var pingRequests = _.filter(list, {
             type: events.Types.Ping,
             direction: 'request'
@@ -674,7 +668,9 @@ function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allo
         if (index < 0) {
             return cb(null);
         }
-        var duration = new Date() - start;
+        var pingRequest = pingRequests[index];
+
+        var duration = pingRequest.time - tc.firstJoinDate;
         var jitter = Math.abs(duration - expectedDuration);
         t.ok(jitter <= allowedJitter, util.format("state changed to %s in %dms (+/- %d) - duration: %d", status, expectedDuration, allowedJitter, duration));
 

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -666,7 +666,6 @@ function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, star
         });
 
         if (index < 0) {
-
             return cb(null);
         }
         var pingRequest = pingRequests[index];

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -625,8 +625,8 @@ function assertStats(t, tc, statusCountsOralive, suspect, faulty, members) {
     return result;
 }
 
-function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allowedJitter) {
-    allowedJitter = allowedJitter || 3000; //Default to 3s jitter
+function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, startFromJoin) {
+    var allowedJitter = 3000; //Default to 3s jitter
 
     var address;
     if (typeof addressOrIndex === 'number') {
@@ -666,11 +666,13 @@ function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allo
         });
 
         if (index < 0) {
+
             return cb(null);
         }
         var pingRequest = pingRequests[index];
 
-        var duration = pingRequest.time - tc.firstJoinDate;
+        var start = startFromJoin ? tc.lastJoinTime : tc.lastPingTime;
+        var duration = pingRequest.time - start;
         var jitter = Math.abs(duration - expectedDuration);
         t.ok(jitter <= allowedJitter, util.format("state changed to %s in %dms (+/- %d) - duration: %d", status, expectedDuration, allowedJitter, duration));
 

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -626,7 +626,7 @@ function assertStats(t, tc, statusCountsOralive, suspect, faulty, members) {
 }
 
 function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allowedJitter) {
-    allowedJitter = allowedJitter || 2000; //Default to 2s jitter
+    allowedJitter = allowedJitter || 3000; //Default to 3s jitter
 
     var address;
     if (typeof addressOrIndex === 'number') {

--- a/test/ringpop-assert.js
+++ b/test/ringpop-assert.js
@@ -635,7 +635,7 @@ function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allo
         address = addressOrIndex;
     }
 
-    var timeOfFirstPing = null;
+    var start = new Date();
 
     return [
         consumePings(t, tc), //consume outstanding pings
@@ -647,10 +647,6 @@ function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allo
 
         if(pingRequests.length === 0) {
             return cb(null);
-        }
-
-        if (timeOfFirstPing === null) {
-            timeOfFirstPing = new Date();
         }
 
         var index = _.findIndex(pingRequests, function(pingRequest) {
@@ -676,7 +672,7 @@ function assertStateChange(t, tc, addressOrIndex, status, expectedDuration, allo
         if (index < 0) {
             return cb(null);
         }
-        var duration = new Date() - timeOfFirstPing;
+        var duration = new Date() - start;
         var jitter = Math.abs(duration - expectedDuration);
 
         t.ok(jitter <= allowedJitter, util.format("state changed to %s in %dms (+/- %d) - duration: %d", status, expectedDuration, allowedJitter, duration));

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -156,9 +156,15 @@ TestCoordinator.prototype.start = function start(callback) {
     var self = this;
     callback = callback || function(){};
 
-    self.once('joined', function joined(){
+    self.on('joined', function joined(){
         // Set firstJoinDate to current Date if not already set.
-        self.firstJoinDate = self.firstJoinDate || new Date();
+        self.firstJoinTime = self.firstJoinTime || Date.now();
+        self.lastJoinTime = Date.now();
+        console.log('got joined: ', self.firstJoinTime, self.lastJoinTime);
+    });
+
+    self.on('ping.send', function pinged(fakeNode, time) {
+        self.lastPingTime = time;
     });
 
     self.startAllFakeNodes(function onFakeNodesUp() {

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -160,7 +160,6 @@ TestCoordinator.prototype.start = function start(callback) {
         // Set firstJoinDate to current Date if not already set.
         self.firstJoinTime = self.firstJoinTime || Date.now();
         self.lastJoinTime = Date.now();
-        console.log('got joined: ', self.firstJoinTime, self.lastJoinTime);
     });
 
     self.on('ping.send', function pinged(fakeNode, time) {

--- a/test/test-coordinator.js
+++ b/test/test-coordinator.js
@@ -156,6 +156,11 @@ TestCoordinator.prototype.start = function start(callback) {
     var self = this;
     callback = callback || function(){};
 
+    self.once('joined', function joined(){
+        // Set firstJoinDate to current Date if not already set.
+        self.firstJoinDate = self.firstJoinDate || new Date();
+    });
+
     self.startAllFakeNodes(function onFakeNodesUp() {
         self.createHostsFile();
         self.startSUT();

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -118,7 +118,13 @@ function testStateTransitions(ns, initial, newState, finalState, incNoDelta, sta
     );
 }
 
-function prepareCluster(insert_fns) {
+function prepareCluster(assertOverrides, insert_fns) {
+    if (typeof assertOverrides === 'function') {
+        insert_fns = assertOverrides;
+        assertOverrides = null;
+    }
+    assertOverrides = assertOverrides || {};
+
     return function(t, tc, n) {
         return [
             // By waiting for the first ping we make sure the SUT is ready to go.
@@ -131,7 +137,7 @@ function prepareCluster(insert_fns) {
             dsl.waitForJoins(t, tc, n),
 
             dsl.assertDetectChecksumMethod(t, tc),
-            dsl.assertStats(t, tc, n+1, 0, 0),
+            dsl.assertStats(t, tc, assertOverrides.alive || (n+1), assertOverrides.suspect || 0, assertOverrides.faulty || 0),
             insert_fns(t, tc, n),
             dsl.expectOnlyPingsAndPingReqs(t, tc),
         ];


### PR DESCRIPTION
Test if state transitions (`suspect` -> `faulty` and  `faulty` -> `tombstone`) are correctly scheduled when the initial membership contains a member with a `suspect` or `tombstone` status.